### PR TITLE
Run pipeline with checks and confirmation

### DIFF
--- a/orchestra_cli/src/cli.py
+++ b/orchestra_cli/src/cli.py
@@ -10,3 +10,6 @@ app = typer.Typer(help="Orchestra CLI – perform operations with Orchestra loca
 app.command(name="validate")(validate)
 app.command(name="import")(import_pipeline)
 app.command(name="run")(run_pipeline)
+
+# Backwards/explicit alias mirroring problem statement
+app.command(name="run-pipeline")(run_pipeline)

--- a/orchestra_cli/src/cli.py
+++ b/orchestra_cli/src/cli.py
@@ -10,6 +10,3 @@ app = typer.Typer(help="Orchestra CLI – perform operations with Orchestra loca
 app.command(name="validate")(validate)
 app.command(name="import")(import_pipeline)
 app.command(name="run")(run_pipeline)
-
-# Backwards/explicit alias mirroring problem statement
-app.command(name="run-pipeline")(run_pipeline)

--- a/orchestra_cli/src/import_pipeline.py
+++ b/orchestra_cli/src/import_pipeline.py
@@ -10,7 +10,7 @@ import httpx
 import typer
 import yaml
 
-from ..utils.constants import API_URL
+from ..utils.constants import get_api_url
 from ..utils.git import detect_repo_root, git_warnings
 from ..utils.styling import bold, green, indent_message, red, yellow
 
@@ -133,7 +133,7 @@ def _load_yaml(file: Path) -> tuple[dict | None, str | None]:
 
 def _validate_yaml_with_api(data: dict) -> tuple[bool, str | None]:
     try:
-        response = httpx.post(API_URL.format("schema"), json=data, timeout=15)
+        response = httpx.post(get_api_url("schema"), json=data, timeout=15)
     except Exception as e:
         return False, f"HTTP request failed: {e}"
 
@@ -223,7 +223,7 @@ def import_pipeline(
         if api_key:
             request_kwargs["headers"] = {"Authorization": f"Bearer {api_key}"}
         response = httpx.post(
-            API_URL.format("import"),
+            get_api_url("import"),
             json=payload,
             timeout=30,
             **request_kwargs,

--- a/orchestra_cli/src/import_pipeline.py
+++ b/orchestra_cli/src/import_pipeline.py
@@ -11,8 +11,8 @@ import typer
 import yaml
 
 from ..utils.constants import API_URL
+from ..utils.git import detect_repo_root, git_warnings
 from ..utils.styling import bold, green, indent_message, red, yellow
-from ..utils.git import _detect_repo_root, _git_warnings
 
 
 def _run_git_command(args: list[str], cwd: Path) -> tuple[bool, str]:
@@ -32,7 +32,7 @@ def _run_git_command(args: list[str], cwd: Path) -> tuple[bool, str]:
 
 
 def _detect_repo_root_local(start_path: Path) -> Path | None:
-    return _detect_repo_root(start_path)
+    return detect_repo_root(start_path)
 
 
 def _detect_repository_url(repo_root: Path) -> str | None:
@@ -119,7 +119,7 @@ def _detect_storage_provider(repository_url: str | None) -> str:
 
 
 def _git_warnings_local(repo_root: Path) -> list[str]:
-    return _git_warnings(repo_root)
+    return git_warnings(repo_root)
 
 
 def _load_yaml(file: Path) -> tuple[dict | None, str | None]:

--- a/orchestra_cli/src/run_pipeline.py
+++ b/orchestra_cli/src/run_pipeline.py
@@ -5,8 +5,8 @@ import httpx
 import typer
 
 from ..utils.constants import API_URL
-from ..utils.git import _detect_repo_root, _git_warnings
-from ..utils.styling import bold, green, indent_message, red, yellow
+from ..utils.git import detect_repo_root, git_warnings
+from ..utils.styling import bold, indent_message, red, yellow
 
 
 def run_pipeline(
@@ -18,12 +18,15 @@ def run_pipeline(
     Run a pipeline in Orchestra.
     """
     api_key = os.getenv("ORCHESTRA_API_KEY")
+    if not api_key:
+        typer.echo(red("ORCHESTRA_API_KEY is not set"))
+        raise typer.Exit(code=1)
 
     # Detect repo root (best-effort). If not a git repo, skip warnings.
     cwd = Path.cwd()
-    repo_root = _detect_repo_root(cwd)
+    repo_root = detect_repo_root(cwd)
     if repo_root is not None:
-        warnings = _git_warnings(repo_root)
+        warnings = git_warnings(repo_root)
         if warnings:
             for w in warnings:
                 typer.echo(yellow(f"⚠ {w}"))
@@ -41,14 +44,11 @@ def run_pipeline(
         payload["commit"] = commit
 
     try:
-        request_kwargs = {}
-        if api_key:
-            request_kwargs["headers"] = {"Authorization": f"Bearer {api_key}"}
         response = httpx.post(
             API_URL.format(f"{alias}/start"),
             json=payload if payload else None,
             timeout=30,
-            **request_kwargs,
+            headers={"Authorization": f"Bearer {api_key}"},
         )
     except Exception as e:
         typer.echo(red(f"HTTP request failed: {e}"))
@@ -59,19 +59,26 @@ def run_pipeline(
             body = response.json()
         except Exception:
             body = {}
-        exec_id = body.get("execution_id") or body.get("run_id") or body.get("id")
-        if exec_id:
-            typer.echo(str(exec_id))
-            raise typer.Exit(code=0)
-        else:
-            typer.echo(green("✅ Run started"))
-            if body:
-                typer.echo(bold(str(body)))
-            raise typer.Exit(code=0)
+        typer.echo(
+            f"Pipeline (alias: {alias}) run successfully started: {body.get('pipeline_run_id')}",
+        )
+        raise typer.Exit(code=0)
 
     typer.echo(red(f"❌ Run failed with status {response.status_code}"))
     try:
-        typer.echo(yellow(indent_message(response.text if not response.headers.get("content-type", "").startswith("application/json") else indent_message(response.json()))))
+        typer.echo(
+            yellow(
+                indent_message(
+                    (
+                        response.text
+                        if not response.headers.get("content-type", "").startswith(
+                            "application/json",
+                        )
+                        else indent_message(response.json())
+                    ),
+                ),
+            ),
+        )
     except Exception:
         typer.echo(yellow(indent_message(response.text)))
     raise typer.Exit(code=1)

--- a/orchestra_cli/src/run_pipeline.py
+++ b/orchestra_cli/src/run_pipeline.py
@@ -1,14 +1,77 @@
+import os
+from pathlib import Path
+
+import httpx
 import typer
 
-from ..utils.styling import red
+from ..utils.constants import API_URL
+from ..utils.git import _detect_repo_root, _git_warnings
+from ..utils.styling import bold, green, indent_message, red, yellow
 
-app = typer.Typer()
 
-
-@app.command()
-def run_pipeline():
+def run_pipeline(
+    alias: str = typer.Option(..., "--alias", "-a", help="Pipeline alias"),
+    branch: str | None = typer.Option(None, "--branch", "-b", help="Git branch name"),
+    commit: str | None = typer.Option(None, "--commit", "-c", help="Commit SHA"),
+):
     """
-    Run a pipeline in Orchestra. (🚧 Coming soon)
+    Run a pipeline in Orchestra.
     """
-    typer.echo(red("🚧 Action not supported yet"))
+    api_key = os.getenv("ORCHESTRA_API_KEY")
+
+    # Detect repo root (best-effort). If not a git repo, skip warnings.
+    cwd = Path.cwd()
+    repo_root = _detect_repo_root(cwd)
+    if repo_root is not None:
+        warnings = _git_warnings(repo_root)
+        if warnings:
+            for w in warnings:
+                typer.echo(yellow(f"⚠ {w}"))
+            typer.echo(bold(yellow("Press Enter to continue or Ctrl+C to abort")))
+            try:
+                input()
+            except KeyboardInterrupt:
+                typer.echo(red("Aborted"))
+                raise typer.Exit(code=1)
+
+    payload: dict[str, str] = {}
+    if branch:
+        payload["branch"] = branch
+    if commit:
+        payload["commit"] = commit
+
+    try:
+        request_kwargs = {}
+        if api_key:
+            request_kwargs["headers"] = {"Authorization": f"Bearer {api_key}"}
+        response = httpx.post(
+            API_URL.format(f"{alias}/start"),
+            json=payload if payload else None,
+            timeout=30,
+            **request_kwargs,
+        )
+    except Exception as e:
+        typer.echo(red(f"HTTP request failed: {e}"))
+        raise typer.Exit(code=1)
+
+    if 200 <= response.status_code < 300:
+        try:
+            body = response.json()
+        except Exception:
+            body = {}
+        exec_id = body.get("execution_id") or body.get("run_id") or body.get("id")
+        if exec_id:
+            typer.echo(str(exec_id))
+            raise typer.Exit(code=0)
+        else:
+            typer.echo(green("✅ Run started"))
+            if body:
+                typer.echo(bold(str(body)))
+            raise typer.Exit(code=0)
+
+    typer.echo(red(f"❌ Run failed with status {response.status_code}"))
+    try:
+        typer.echo(yellow(indent_message(response.text if not response.headers.get("content-type", "").startswith("application/json") else indent_message(response.json()))))
+    except Exception:
+        typer.echo(yellow(indent_message(response.text)))
     raise typer.Exit(code=1)

--- a/orchestra_cli/src/validate_pipeline.py
+++ b/orchestra_cli/src/validate_pipeline.py
@@ -5,7 +5,7 @@ import httpx
 import typer
 import yaml
 
-from ..utils.constants import API_URL
+from ..utils.constants import get_api_url
 from ..utils.styling import bold, green, indent_message, red, yellow
 
 
@@ -38,7 +38,7 @@ def validate(file: Path = typer.Argument(..., help="YAML file to validate")):
         raise typer.Exit(code=1)
 
     try:
-        response = httpx.post(API_URL.format("schema"), json=data, timeout=10)
+        response = httpx.post(get_api_url("schema"), json=data, timeout=10)
     except Exception as e:
         typer.echo(red(f"HTTP request failed: {e}"))
         raise typer.Exit(code=1)

--- a/orchestra_cli/tests/conftest.py
+++ b/orchestra_cli/tests/conftest.py
@@ -1,0 +1,14 @@
+def make_git_subprocess_mock(mapping: dict[tuple[str, ...], tuple[int, str, str]]):
+    class Result:
+        def __init__(self, returncode: int, stdout: str = "", stderr: str = ""):
+            self.returncode = returncode
+            self.stdout = stdout
+            self.stderr = stderr
+
+    def _mock_run(args, cwd=None, capture_output=False, text=False, check=False):  # noqa: ARG001
+        # args begins with ["git", ...]
+        key = tuple(args[1:])
+        rc, out, err = mapping.get(key, (1, "", ""))
+        return Result(rc, out, err)
+
+    return _mock_run

--- a/orchestra_cli/tests/test_run_pipeline.py
+++ b/orchestra_cli/tests/test_run_pipeline.py
@@ -1,0 +1,130 @@
+from pathlib import Path
+
+from pytest_httpx import HTTPXMock
+from typer.testing import CliRunner
+
+from orchestra_cli.src.cli import app
+
+from .test_import_pipeline import make_git_subprocess_mock
+
+
+runner = CliRunner()
+
+
+def test_run_success_simple(httpx_mock: HTTPXMock, monkeypatch, tmp_path: Path):
+    # Mock git repo to trigger no warnings
+    repo_root = tmp_path
+    mapping = {
+        ("rev-parse", "--show-toplevel"): (0, str(repo_root), ""),
+        ("status", "--porcelain"): (0, "", ""),
+        ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"): (1, "", ""),
+    }
+    import subprocess
+
+    monkeypatch.setattr(subprocess, "run", make_git_subprocess_mock(mapping))
+
+    httpx_mock.add_response(
+        method="POST",
+        url="https://dev.getorchestra.io/api/engine/public/pipelines/demo/start",
+        json={"execution_id": "run-123"},
+        status_code=200,
+    )
+
+    result = runner.invoke(app, ["run", "--alias", "demo"])
+    assert result.exit_code == 0
+    assert result.output.strip() == "run-123"
+
+
+def test_run_with_branch_commit(httpx_mock: HTTPXMock, monkeypatch, tmp_path: Path):
+    repo_root = tmp_path
+    mapping = {
+        ("rev-parse", "--show-toplevel"): (0, str(repo_root), ""),
+        ("status", "--porcelain"): (0, "", ""),
+        ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"): (1, "", ""),
+    }
+    import subprocess
+
+    monkeypatch.setattr(subprocess, "run", make_git_subprocess_mock(mapping))
+
+    def _assert_request(request):
+        data = request.read()
+        assert b"branch" in data and b"main" in data
+        assert b"commit" in data and b"deadbeef" in data
+        return True
+
+    httpx_mock.add_response(
+        method="POST",
+        url="https://dev.getorchestra.io/api/engine/public/pipelines/demo/start",
+        match_content=_assert_request,
+        json={"execution_id": "run-456"},
+        status_code=201,
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            "--alias",
+            "demo",
+            "--branch",
+            "main",
+            "--commit",
+            "deadbeef",
+        ],
+    )
+    assert result.exit_code == 0
+    assert result.output.strip() == "run-456"
+
+
+def test_run_warnings_prompt(httpx_mock: HTTPXMock, monkeypatch, tmp_path: Path):
+    repo_root = tmp_path
+    mapping = {
+        ("rev-parse", "--show-toplevel"): (0, str(repo_root), ""),
+        ("status", "--porcelain"): (0, " M file.txt\n", ""),
+        ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"): (0, "origin/main", ""),
+        ("rev-parse", "HEAD"): (0, "aaaa", ""),
+        ("rev-parse", "@{u}"): (0, "bbbb", ""),
+        ("status", "-sb"): (0, "## main...origin/main [behind 1]", ""),
+    }
+    import subprocess
+
+    monkeypatch.setattr(subprocess, "run", make_git_subprocess_mock(mapping))
+
+    httpx_mock.add_response(
+        method="POST",
+        url="https://dev.getorchestra.io/api/engine/public/pipelines/demo/start",
+        json={"execution_id": "run-789"},
+        status_code=200,
+    )
+
+    # Simulate pressing Enter
+    result = runner.invoke(app, ["run", "--alias", "demo"], input="\n")
+    assert result.exit_code == 0
+    assert "⚠ Uncommitted changes" in result.output
+    assert "Local branch SHA does not match remote branch SHA" in result.output
+    assert "Press Enter to continue" in result.output
+    assert result.output.strip().endswith("run-789")
+
+
+def test_run_api_error(httpx_mock: HTTPXMock, monkeypatch, tmp_path: Path):
+    repo_root = tmp_path
+    mapping = {
+        ("rev-parse", "--show-toplevel"): (0, str(repo_root), ""),
+        ("status", "--porcelain"): (0, "", ""),
+        ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"): (1, "", ""),
+    }
+    import subprocess
+
+    monkeypatch.setattr(subprocess, "run", make_git_subprocess_mock(mapping))
+
+    httpx_mock.add_response(
+        method="POST",
+        url="https://dev.getorchestra.io/api/engine/public/pipelines/demo/start",
+        json={"detail": "bad"},
+        status_code=400,
+    )
+
+    result = runner.invoke(app, ["run", "--alias", "demo"])
+    assert result.exit_code == 1
+    assert "Run failed" in result.output
+

--- a/orchestra_cli/tests/test_run_pipeline.py
+++ b/orchestra_cli/tests/test_run_pipeline.py
@@ -7,7 +7,6 @@ from orchestra_cli.src.cli import app
 
 from .test_import_pipeline import make_git_subprocess_mock
 
-
 runner = CliRunner()
 
 
@@ -127,4 +126,3 @@ def test_run_api_error(httpx_mock: HTTPXMock, monkeypatch, tmp_path: Path):
     result = runner.invoke(app, ["run", "--alias", "demo"])
     assert result.exit_code == 1
     assert "Run failed" in result.output
-

--- a/orchestra_cli/tests/test_run_pipeline.py
+++ b/orchestra_cli/tests/test_run_pipeline.py
@@ -1,13 +1,21 @@
 from pathlib import Path
 
+import pytest
 from pytest_httpx import HTTPXMock
 from typer.testing import CliRunner
 
 from orchestra_cli.src.cli import app
-
-from .test_import_pipeline import make_git_subprocess_mock
+from tests.conftest import make_git_subprocess_mock
 
 runner = CliRunner()
+mock_pipeline_run_id = "798d7121-6809-4148-aecb-26740cfabdf1"
+mock_api_key = "fake-key"
+
+
+@pytest.fixture(autouse=True)
+def mock_env(monkeypatch):
+    monkeypatch.setenv("ORCHESTRA_API_KEY", mock_api_key)
+    monkeypatch.setenv("BASE_URL", "")
 
 
 def test_run_success_simple(httpx_mock: HTTPXMock, monkeypatch, tmp_path: Path):
@@ -24,14 +32,17 @@ def test_run_success_simple(httpx_mock: HTTPXMock, monkeypatch, tmp_path: Path):
 
     httpx_mock.add_response(
         method="POST",
-        url="https://dev.getorchestra.io/api/engine/public/pipelines/demo/start",
-        json={"execution_id": "run-123"},
+        url="https://app.getorchestra.io/api/engine/public/pipelines/demo/start",
+        json={"pipelineRunId": mock_pipeline_run_id},
+        match_headers={"Authorization": f"Bearer {mock_api_key}"},
         status_code=200,
     )
 
     result = runner.invoke(app, ["run", "--alias", "demo"])
     assert result.exit_code == 0
-    assert result.output.strip() == "run-123"
+    assert (
+        result.output.strip() == f"Started pipeline (alias: demo), run id: {mock_pipeline_run_id}"
+    )
 
 
 def test_run_with_branch_commit(httpx_mock: HTTPXMock, monkeypatch, tmp_path: Path):
@@ -45,17 +56,12 @@ def test_run_with_branch_commit(httpx_mock: HTTPXMock, monkeypatch, tmp_path: Pa
 
     monkeypatch.setattr(subprocess, "run", make_git_subprocess_mock(mapping))
 
-    def _assert_request(request):
-        data = request.read()
-        assert b"branch" in data and b"main" in data
-        assert b"commit" in data and b"deadbeef" in data
-        return True
-
     httpx_mock.add_response(
         method="POST",
-        url="https://dev.getorchestra.io/api/engine/public/pipelines/demo/start",
-        match_content=_assert_request,
-        json={"execution_id": "run-456"},
+        url="https://app.getorchestra.io/api/engine/public/pipelines/demo/start",
+        match_headers={"Authorization": f"Bearer {mock_api_key}"},
+        match_json={"branch": "main", "commit": "deadbeef"},
+        json={"pipelineRunId": mock_pipeline_run_id},
         status_code=201,
     )
 
@@ -72,7 +78,9 @@ def test_run_with_branch_commit(httpx_mock: HTTPXMock, monkeypatch, tmp_path: Pa
         ],
     )
     assert result.exit_code == 0
-    assert result.output.strip() == "run-456"
+    assert (
+        result.output.strip() == f"Started pipeline (alias: demo), run id: {mock_pipeline_run_id}"
+    )
 
 
 def test_run_warnings_prompt(httpx_mock: HTTPXMock, monkeypatch, tmp_path: Path):
@@ -91,8 +99,9 @@ def test_run_warnings_prompt(httpx_mock: HTTPXMock, monkeypatch, tmp_path: Path)
 
     httpx_mock.add_response(
         method="POST",
-        url="https://dev.getorchestra.io/api/engine/public/pipelines/demo/start",
-        json={"execution_id": "run-789"},
+        url="https://app.getorchestra.io/api/engine/public/pipelines/demo/start",
+        match_headers={"Authorization": f"Bearer {mock_api_key}"},
+        json={"pipelineRunId": mock_pipeline_run_id},
         status_code=200,
     )
 
@@ -102,7 +111,9 @@ def test_run_warnings_prompt(httpx_mock: HTTPXMock, monkeypatch, tmp_path: Path)
     assert "⚠ Uncommitted changes" in result.output
     assert "Local branch SHA does not match remote branch SHA" in result.output
     assert "Press Enter to continue" in result.output
-    assert result.output.strip().endswith("run-789")
+    assert result.output.strip().endswith(
+        f"Started pipeline (alias: demo), run id: {mock_pipeline_run_id}",
+    )
 
 
 def test_run_api_error(httpx_mock: HTTPXMock, monkeypatch, tmp_path: Path):
@@ -118,7 +129,8 @@ def test_run_api_error(httpx_mock: HTTPXMock, monkeypatch, tmp_path: Path):
 
     httpx_mock.add_response(
         method="POST",
-        url="https://dev.getorchestra.io/api/engine/public/pipelines/demo/start",
+        url="https://app.getorchestra.io/api/engine/public/pipelines/demo/start",
+        match_headers={"Authorization": f"Bearer {mock_api_key}"},
         json={"detail": "bad"},
         status_code=400,
     )
@@ -126,3 +138,119 @@ def test_run_api_error(httpx_mock: HTTPXMock, monkeypatch, tmp_path: Path):
     result = runner.invoke(app, ["run", "--alias", "demo"])
     assert result.exit_code == 1
     assert "Run failed" in result.output
+
+
+def test_run_wait_success(httpx_mock: HTTPXMock, monkeypatch, tmp_path: Path):
+    # Mock git repo to trigger no warnings
+    repo_root = tmp_path
+    mapping = {
+        ("rev-parse", "--show-toplevel"): (0, str(repo_root), ""),
+        ("status", "--porcelain"): (0, "", ""),
+        ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"): (1, "", ""),
+    }
+    import subprocess
+    import time
+
+    monkeypatch.setattr(subprocess, "run", make_git_subprocess_mock(mapping))
+    monkeypatch.setattr(time, "sleep", lambda _: None)
+
+    # Start run
+    httpx_mock.add_response(
+        method="POST",
+        url="https://app.getorchestra.io/api/engine/public/pipelines/demo/start",
+        json={"pipelineRunId": mock_pipeline_run_id},
+        status_code=200,
+    )
+
+    # Polling: RUNNING -> SUCCEEDED
+    httpx_mock.add_response(
+        method="GET",
+        url=f"https://app.getorchestra.io/api/engine/public/pipeline_runs/{mock_pipeline_run_id}/status",
+        json={"runStatus": "RUNNING", "pipelineName": "demo"},
+        status_code=200,
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url=f"https://app.getorchestra.io/api/engine/public/pipeline_runs/{mock_pipeline_run_id}/status",
+        json={"runStatus": "SUCCEEDED", "pipelineName": "demo"},
+        status_code=200,
+    )
+
+    result = runner.invoke(app, ["run", "--alias", "demo", "--wait"])
+    assert result.exit_code == 0
+    # Last printed line should be the run id
+    assert (
+        result.output.strip().splitlines()[0]
+        == f"Started pipeline (alias: demo), run id: {mock_pipeline_run_id}"
+    )
+    assert result.output.strip().splitlines()[-2] == "✅ Pipeline succeeded"
+    assert result.output.strip().splitlines()[-1] == mock_pipeline_run_id
+
+
+def test_run_wait_failed(httpx_mock: HTTPXMock, monkeypatch, tmp_path: Path):
+    repo_root = tmp_path
+    mapping = {
+        ("rev-parse", "--show-toplevel"): (0, str(repo_root), ""),
+        ("status", "--porcelain"): (0, "", ""),
+        ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"): (1, "", ""),
+    }
+    import subprocess
+    import time
+
+    monkeypatch.setattr(subprocess, "run", make_git_subprocess_mock(mapping))
+    monkeypatch.setattr(time, "sleep", lambda _: None)
+
+    httpx_mock.add_response(
+        method="POST",
+        url="https://app.getorchestra.io/api/engine/public/pipelines/demo/start",
+        json={"pipelineRunId": "run-xyz"},
+        status_code=200,
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url="https://app.getorchestra.io/api/engine/public/pipeline_runs/run-xyz/status",
+        json={"runStatus": "RUNNING", "pipelineName": "demo"},
+        status_code=200,
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url="https://app.getorchestra.io/api/engine/public/pipeline_runs/run-xyz/status",
+        json={"runStatus": "FAILED", "pipelineName": "demo"},
+        status_code=200,
+    )
+
+    result = runner.invoke(app, ["run", "--alias", "demo", "--wait"])
+    assert result.exit_code == 1
+    assert "status FAILED" in result.output
+    assert "/pipeline-runs/run-xyz/lineage" in result.output
+
+
+def test_run_wait_warning(httpx_mock: HTTPXMock, monkeypatch, tmp_path: Path):
+    repo_root = tmp_path
+    mapping = {
+        ("rev-parse", "--show-toplevel"): (0, str(repo_root), ""),
+        ("status", "--porcelain"): (0, "", ""),
+        ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"): (1, "", ""),
+    }
+    import subprocess
+    import time
+
+    monkeypatch.setattr(time, "sleep", lambda _: None)
+    monkeypatch.setattr(subprocess, "run", make_git_subprocess_mock(mapping))
+
+    httpx_mock.add_response(
+        method="POST",
+        url="https://app.getorchestra.io/api/engine/public/pipelines/demo/start",
+        json={"pipelineRunId": "run-warn"},
+        status_code=200,
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url="https://app.getorchestra.io/api/engine/public/pipeline_runs/run-warn/status",
+        json={"runStatus": "WARNING", "pipelineName": "demo"},
+        status_code=200,
+    )
+
+    result = runner.invoke(app, ["run", "--alias", "demo", "--wait"])
+    assert result.exit_code == 0
+    assert result.output.strip().splitlines()[-1] == "run-warn"

--- a/orchestra_cli/utils/constants.py
+++ b/orchestra_cli/utils/constants.py
@@ -1,1 +1,6 @@
-API_URL = "https://dev.getorchestra.io/api/engine/public/pipelines/{}"
+import os
+
+
+def get_api_url(path: str):
+    base_url = os.getenv("BASE_URL") or "https://app.getorchestra.io/api/engine/public/pipelines/{}"
+    return base_url.format(path)

--- a/orchestra_cli/utils/git.py
+++ b/orchestra_cli/utils/git.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def _run_git_command(args: list[str], cwd: Path) -> tuple[bool, str]:
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode == 0:
+            return True, result.stdout.strip()
+        return False, result.stderr.strip() or result.stdout.strip()
+    except Exception as e:
+        return False, str(e)
+
+
+def _detect_repo_root(start_path: Path) -> Path | None:
+    ok, out = _run_git_command(["rev-parse", "--show-toplevel"], start_path)
+    if not ok:
+        return None
+    return Path(out)
+
+
+def _git_warnings(repo_root: Path) -> list[str]:
+    warnings: list[str] = []
+    # Uncommitted changes
+    ok, out = _run_git_command(["status", "--porcelain"], repo_root)
+    if ok and out:
+        warnings.append("Uncommitted changes detected in repository")
+
+    # Not on latest commit of the branch / local vs remote mismatch
+    # Try to compare local HEAD to upstream if it exists
+    ok, branch = _run_git_command(
+        ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
+        repo_root,
+    )
+    if ok and branch:
+        ok_head, head = _run_git_command(["rev-parse", "HEAD"], repo_root)
+        ok_up, upstream = _run_git_command(["rev-parse", "@{u}"], repo_root)
+        if ok_head and ok_up and head and upstream and head != upstream:
+            warnings.append("Local branch SHA does not match remote branch SHA")
+            # If behind, call out explicitly
+            ok_stat, stat = _run_git_command(["status", "-sb"], repo_root)
+            if ok_stat and "behind" in stat:
+                warnings.append("You are not on latest HEAD of the branch (behind remote)")
+    return warnings
+

--- a/orchestra_cli/utils/git.py
+++ b/orchestra_cli/utils/git.py
@@ -20,14 +20,14 @@ def _run_git_command(args: list[str], cwd: Path) -> tuple[bool, str]:
         return False, str(e)
 
 
-def _detect_repo_root(start_path: Path) -> Path | None:
+def detect_repo_root(start_path: Path) -> Path | None:
     ok, out = _run_git_command(["rev-parse", "--show-toplevel"], start_path)
     if not ok:
         return None
     return Path(out)
 
 
-def _git_warnings(repo_root: Path) -> list[str]:
+def git_warnings(repo_root: Path) -> list[str]:
     warnings: list[str] = []
     # Uncommitted changes
     ok, out = _run_git_command(["status", "--porcelain"], repo_root)
@@ -50,4 +50,3 @@ def _git_warnings(repo_root: Path) -> list[str]:
             if ok_stat and "behind" in stat:
                 warnings.append("You are not on latest HEAD of the branch (behind remote)")
     return warnings
-


### PR DESCRIPTION
Implement `orchestra-cli run` command to execute pipelines with pre-run git warnings and extract shared git utilities.

---
<a href="https://cursor.com/background-agent?bcId=bc-e7665219-ae23-4a9d-8795-57836cebe971"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e7665219-ae23-4a9d-8795-57836cebe971"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

