### PR TITLE
add validation + tests

### DIFF
--- a/orchestra_cli/src/import_pipeline.py
+++ b/orchestra_cli/src/import_pipeline.py
@@ -2,6 +2,7 @@ import json
 import os
 import re
 from pathlib import Path
+from typing import Any
 
 import httpx
 import typer
@@ -98,6 +99,36 @@ def _validate_yaml_with_api(data: dict) -> tuple[bool, str | None]:
         return False, response.text
 
 
+def _validate_task_group_references(data: dict) -> list[str]:
+    """Return error strings for any task_groups['<id>'] condition expression
+    that references a pipeline entry that is not a task group."""
+    pipeline = data.get("pipeline", {})
+    if not isinstance(pipeline, dict):
+        return []
+    task_group_ids = {k for k, v in pipeline.items() if isinstance(v, dict) and "tasks" in v}
+    pattern = re.compile(r"task_groups\['([^']+)'\]")
+    errors: list[str] = []
+
+    def scan(obj: Any, path: str = "") -> None:
+        if isinstance(obj, dict):
+            for k, v in obj.items():
+                scan(v, f"{path}.{k}" if path else k)
+        elif isinstance(obj, list):
+            for i, item in enumerate(obj):
+                scan(item, f"{path}[{i}]")
+        elif isinstance(obj, str):
+            for m in pattern.finditer(obj):
+                ref_id = m.group(1)
+                if ref_id not in task_group_ids:
+                    errors.append(
+                        f"condition at '{path}' references task_groups['{ref_id}'], "
+                        f"but '{ref_id}' is not a task group (it has no 'tasks' key).",
+                    )
+
+    scan(data)
+    return errors
+
+
 def import_pipeline(
     alias: str = typer.Option(..., "--alias", "-a", help="Pipeline alias"),
     path: Path = typer.Option(
@@ -135,6 +166,13 @@ def import_pipeline(
     data, err = _load_yaml(path)
     if err is not None:
         typer.echo(red(f"Invalid YAML: {err}"))
+        raise typer.Exit(code=1)
+
+    ref_errors = _validate_task_group_references(data or {})
+    if ref_errors:
+        typer.echo(red("❌ Validation failed (local check)\n"))
+        for e in ref_errors:
+            typer.echo(red(indent_message(e)))
         raise typer.Exit(code=1)
 
     ok, err_msg = _validate_yaml_with_api(data or {})

--- a/orchestra_cli/src/pipeline_upsert.py
+++ b/orchestra_cli/src/pipeline_upsert.py
@@ -29,15 +29,16 @@ def load_validated_pipeline_data(path: Path) -> dict:
         raise typer.Exit(code=1)
 
     ref_errors = _validate_task_group_references(data or {})
+    validation_failed = "❌ Validation failed\n"
     if ref_errors:
-        typer.echo(red("❌ Validation failed (local check)\n"))
+        typer.echo(red(validation_failed))
         for e in ref_errors:
             typer.echo(red(indent_message(e)))
         raise typer.Exit(code=1)
 
     ok, err_msg = _validate_yaml_with_api(data or {})
     if not ok:
-        typer.echo(red("❌ Validation failed"))
+        typer.echo(red(validation_failed))
         if err_msg:
             typer.echo(yellow(indent_message(err_msg)))
         raise typer.Exit(code=1)

--- a/orchestra_cli/src/pipeline_upsert.py
+++ b/orchestra_cli/src/pipeline_upsert.py
@@ -7,7 +7,7 @@ import typer
 
 from ..utils.constants import get_pipeline_edit_url
 from ..utils.styling import green, indent_message, red, yellow
-from .import_pipeline import _load_yaml, _validate_yaml_with_api
+from .import_pipeline import _load_yaml, _validate_task_group_references, _validate_yaml_with_api
 
 
 def require_api_key() -> str:
@@ -26,6 +26,13 @@ def load_validated_pipeline_data(path: Path) -> dict:
     data, err = _load_yaml(path)
     if err is not None:
         typer.echo(red(f"Invalid YAML: {err}"))
+        raise typer.Exit(code=1)
+
+    ref_errors = _validate_task_group_references(data or {})
+    if ref_errors:
+        typer.echo(red("❌ Validation failed (local check)\n"))
+        for e in ref_errors:
+            typer.echo(red(indent_message(e)))
         raise typer.Exit(code=1)
 
     ok, err_msg = _validate_yaml_with_api(data or {})

--- a/orchestra_cli/src/validate_pipeline.py
+++ b/orchestra_cli/src/validate_pipeline.py
@@ -7,6 +7,7 @@ import yaml
 
 from ..utils.constants import get_api_url
 from ..utils.styling import bold, green, indent_message, red, yellow
+from .import_pipeline import _validate_task_group_references
 
 
 def get_yaml_snippet(data: Any, loc: list[Any]) -> dict[str, Any] | None:
@@ -35,6 +36,13 @@ def validate(file: Path = typer.Argument(..., help="YAML file to validate")):
             data = yaml.safe_load(f)
     except Exception as e:
         typer.echo(red(f"Invalid YAML: {e}"))
+        raise typer.Exit(code=1)
+
+    ref_errors = _validate_task_group_references(data)
+    if ref_errors:
+        typer.echo(red("❌ Validation failed (local check)\n"))
+        for e in ref_errors:
+            typer.echo(red(indent_message(e)))
         raise typer.Exit(code=1)
 
     try:

--- a/orchestra_cli/tests/test_import_pipeline.py
+++ b/orchestra_cli/tests/test_import_pipeline.py
@@ -215,6 +215,49 @@ def test_missing_repo_or_branch(monkeypatch, tmp_path: Path, httpx_mock: HTTPXMo
     assert "Could not detect repository URL from git" in result.output
 
 
+def test_import_bad_task_group_reference_fails_locally(tmp_path: Path):
+    """A condition referencing a standalone task via task_groups[...] should fail
+    before any API or git call is made."""
+    yaml_file = tmp_path / "pipe.yaml"
+    yaml_file.write_text(
+        "version: v1\n"
+        "name: test\n"
+        "pipeline:\n"
+        "  real_group:\n"
+        "    tasks:\n"
+        "      t1:\n"
+        "        integration: DBT_CORE\n"
+        "        integration_job: DBT_CORE_EXECUTE\n"
+        "        parameters: {}\n"
+        "        depends_on: []\n"
+        "    depends_on: []\n"
+        "    name: ''\n"
+        "  standalone_task:\n"
+        "    integration: ORCHESTRA\n"
+        "    integration_job: APPROVAL\n"
+        "    parameters: {}\n"
+        "    depends_on: []\n"
+        "    name: Approve\n"
+        "  consumer_group:\n"
+        "    tasks:\n"
+        "      t2:\n"
+        "        integration: PYTHON\n"
+        "        integration_job: PYTHON_EXECUTE_SCRIPT\n"
+        "        parameters: {}\n"
+        "        depends_on: []\n"
+        "    depends_on:\n"
+        "    - standalone_task\n"
+        "    condition: \"${{ task_groups['standalone_task'].any().status == 'SUCCEEDED' }}\"\n"
+        "    name: ''\n",
+    )
+
+    result = runner.invoke(app, ["import", "--alias", "demo", "--path", str(yaml_file)])
+
+    assert result.exit_code == 1
+    assert "local check" in result.output
+    assert "standalone_task" in result.output
+
+
 def test_warnings_printed(monkeypatch, tmp_path: Path, httpx_mock: HTTPXMock):
     repo_root = tmp_path
     f = repo_root / "p.yaml"

--- a/orchestra_cli/tests/test_validate_pipeline.py
+++ b/orchestra_cli/tests/test_validate_pipeline.py
@@ -1,11 +1,137 @@
+from pathlib import Path
+
+import pytest
+from pytest_httpx import HTTPXMock
 from typer.testing import CliRunner
 
 from orchestra_cli.src.cli import app
 
 runner = CliRunner()
 
+# YAML where a condition references a standalone task (no 'tasks' key) via task_groups[...]
+YAML_BAD_TASK_GROUP_REF = """\
+version: v1
+name: test
+pipeline:
+  real_group:
+    tasks:
+      t1:
+        integration: DBT_CORE
+        integration_job: DBT_CORE_EXECUTE
+        parameters: {}
+        depends_on: []
+    depends_on: []
+    name: ''
+  standalone_task:
+    integration: ORCHESTRA
+    integration_job: APPROVAL
+    parameters: {}
+    depends_on: []
+    name: Approve
+  consumer_group:
+    tasks:
+      t2:
+        integration: PYTHON
+        integration_job: PYTHON_EXECUTE_SCRIPT
+        parameters: {}
+        depends_on: []
+        condition: "${{ task_groups['standalone_task'].any().status == 'SUCCEEDED' }}"
+        name: bad ref in task condition
+    depends_on:
+    - standalone_task
+    condition: "${{ task_groups['standalone_task'].any().status == 'SUCCEEDED' }}"
+    name: ''
+"""
+
+# YAML where all task_groups[...] conditions reference real task groups
+YAML_VALID_TASK_GROUP_REF = """\
+version: v1
+name: test
+pipeline:
+  real_group:
+    tasks:
+      t1:
+        integration: DBT_CORE
+        integration_job: DBT_CORE_EXECUTE
+        parameters: {}
+        depends_on: []
+    depends_on: []
+    name: ''
+  consumer_group:
+    tasks:
+      t2:
+        integration: PYTHON
+        integration_job: PYTHON_EXECUTE_SCRIPT
+        parameters: {}
+        depends_on: []
+        condition: "${{ task_groups['real_group'].any().status == 'SUCCEEDED' }}"
+        name: valid ref in task condition
+    depends_on:
+    - real_group
+    condition: "${{ task_groups['real_group'].any().status == 'SUCCEEDED' }}"
+    name: ''
+"""
+
 
 def test_validate_missing_file():
     result = runner.invoke(app, ["validate", "not_a_file.yaml"])
     assert result.exit_code == 1
     assert "File not found" in result.output
+
+
+def test_validate_bad_task_group_reference_fails_locally(tmp_path: Path):
+    """A condition referencing a standalone task via task_groups[...] should fail
+    before any API call is made."""
+    yaml_file = tmp_path / "pipe.yaml"
+    yaml_file.write_text(YAML_BAD_TASK_GROUP_REF)
+
+    result = runner.invoke(app, ["validate", str(yaml_file)])
+
+    assert result.exit_code == 1
+    assert "local check" in result.output
+    assert "standalone_task" in result.output
+
+
+def test_validate_valid_task_group_reference_passes_through(
+    tmp_path: Path,
+    httpx_mock: HTTPXMock,
+):
+    """When all task_groups[...] references point to real task groups the local
+    check passes and the request reaches the API."""
+    yaml_file = tmp_path / "pipe.yaml"
+    yaml_file.write_text(YAML_VALID_TASK_GROUP_REF)
+
+    httpx_mock.add_response(
+        method="POST",
+        url="https://app.getorchestra.io/api/engine/public/pipelines/schema",
+        json={"ok": True},
+        status_code=200,
+    )
+
+    result = runner.invoke(app, ["validate", str(yaml_file)])
+
+    assert result.exit_code == 0
+    assert "Validation passed" in result.output
+
+
+@pytest.mark.parametrize("yaml_content", ["name: test\nversion: v1\n", "{}"])
+def test_validate_no_pipeline_key_passes_local_check(
+    tmp_path: Path,
+    httpx_mock: HTTPXMock,
+    yaml_content: str,
+):
+    """YAML without a pipeline key has nothing to cross-reference; the local
+    check should pass through to the API."""
+    yaml_file = tmp_path / "pipe.yaml"
+    yaml_file.write_text(yaml_content)
+
+    httpx_mock.add_response(
+        method="POST",
+        url="https://app.getorchestra.io/api/engine/public/pipelines/schema",
+        json={"ok": True},
+        status_code=200,
+    )
+
+    result = runner.invoke(app, ["validate", str(yaml_file)])
+
+    assert result.exit_code == 0


### PR DESCRIPTION
Orchestra uploaded a pipeline that was invalid. There was no validation to catch this. This PR adds that validation.

https://orchestra-dcj6077.slack.com/archives/C091ZD5MPTP/p1773997785480539

This is what it looks like now if a task ID has been referred to as a task_group ID
<img width="821" height="121" alt="image" src="https://github.com/user-attachments/assets/6aebb53f-e978-4647-8bd3-e11b6930eb84" />
