### PR TITLE
ENG-9858: restructure CLI to noun/verb commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,12 +85,12 @@ No system-level dependencies beyond Python 3.12 and git (used at runtime by the 
 ```bash
 # Run via uv (no install required)
 uv run orchestra --help
-uv run orchestra validate valid.yaml
-uv run orchestra import --alias my-pipeline --path ./valid.yaml
-uv run orchestra run --alias my-pipeline --no-wait
+uv run orchestra pipeline validate valid.yaml
+uv run orchestra pipeline import --alias my-pipeline --path ./valid.yaml
+uv run orchestra pipeline run --alias my-pipeline --no-wait
 
 # With env vars from a .env file
-uv run --env-file .env orchestra run --alias my-pipeline
+uv run --env-file .env orchestra pipeline run --alias my-pipeline
 
 # After editable install
 orchestra --help
@@ -98,6 +98,8 @@ orchestra-cli --help   # equivalent alias
 ```
 
 Both `orchestra` and `orchestra-cli` entry points map to `orchestra_cli.src.cli:app`.
+
+The CLI uses a `noun verb` structure (currently the only noun is `pipeline`): `orchestra pipeline validate`, `orchestra pipeline import`, `orchestra pipeline new`, `orchestra pipeline update`, `orchestra pipeline get`, `orchestra pipeline delete`, `orchestra pipeline run`. The previous flat command names (`validate`, `import`, `run`, `fetch-pipelines`, `create-pipeline`, `update-pipeline`, `delete-pipeline`) are registered as hidden top-level aliases for backwards compatibility. Prefer the noun/verb form in new code and docs.
 
 ---
 
@@ -165,13 +167,13 @@ uv run pytest                       # fast, no network, no side effects
 uv run ruff check .                 # read-only lint
 uv run black --check .              # read-only format check
 uv run pyright                      # type checking
-uv run orchestra validate <file>    # calls the Orchestra API (schema endpoint, no auth required)
+uv run orchestra pipeline validate <file>  # calls the Orchestra API (schema endpoint, no auth required)
 ```
 
 **Requires caution:**
 ```bash
-uv run orchestra import ...         # creates a pipeline in the Orchestra backend (requires API key)
-uv run orchestra run ...            # starts a live pipeline run (requires API key, has polling loop)
+uv run orchestra pipeline import ...       # creates a pipeline in the Orchestra backend (requires API key)
+uv run orchestra pipeline run ...          # starts a live pipeline run (requires API key, has polling loop)
 uv build                            # builds a distributable package
 uv publish                          # publishes to PyPI — only run intentionally with correct version
 make publish                        # same as uv publish

--- a/README.md
+++ b/README.md
@@ -20,31 +20,51 @@ pipx install orchestra-cli
 
 ## Environment variables
 
-- `ORCHESTRA_API_KEY`: Required for actions that call the API (`import`, `create-pipeline`, `update-pipeline`, `delete-pipeline`, `run`).
+- `ORCHESTRA_API_KEY`: Required for actions that call the API (`pipeline import`, `pipeline new`, `pipeline update`, `pipeline delete`, `pipeline run`).
 - `BASE_URL`: Optional. Override the default Orchestra host (`https://app.getorchestra.io`) for non‑production/testing.
 
-## Commands overview
+## Command structure
 
-- `validate`: Validate a pipeline YAML locally against the Orchestra API schema.
-- `import`: Register a pipeline YAML (from a git repo) with Orchestra under an alias.
-- `fetch-pipelines`: Fetch the pipelines visible to the current API key as JSON.
-- `create-pipeline`: Create an Orchestra-backed pipeline from a local YAML file.
-- `update-pipeline`: Update an existing Orchestra-backed pipeline from a local YAML file.
-- `delete-pipeline`: Delete an existing pipeline by alias.
-- `run`: Start a pipeline run by alias, optionally pinning branch/commit and waiting for completion.
+Commands follow a `noun verb` shape. The current noun is `pipeline`:
 
-Use `orchestra --help` or `orchestra <command> --help` for built-in help.
+| Command | Description |
+|---|---|
+| `orchestra pipeline validate <file>` | Validate a pipeline YAML locally against the Orchestra API schema. |
+| `orchestra pipeline import` | Register a pipeline YAML (from a git repo) with Orchestra under an alias. |
+| `orchestra pipeline get` | Fetch the pipelines visible to the current API key as JSON. |
+| `orchestra pipeline new` | Create an Orchestra-backed pipeline from a local YAML file. |
+| `orchestra pipeline update` | Update an existing Orchestra-backed pipeline from a local YAML file. |
+| `orchestra pipeline delete` | Delete an existing pipeline by alias. |
+| `orchestra pipeline run` | Start a pipeline run by alias, optionally pinning branch/commit and waiting for completion. |
+
+Use `orchestra --help`, `orchestra pipeline --help`, or `orchestra pipeline <verb> --help` for built-in help.
+
+### Legacy command names
+
+The previous flat command names continue to work as hidden top-level aliases so existing scripts keep running:
+
+| Legacy alias | New canonical form |
+|---|---|
+| `orchestra validate` | `orchestra pipeline validate` |
+| `orchestra import` | `orchestra pipeline import` |
+| `orchestra fetch-pipelines` | `orchestra pipeline get` |
+| `orchestra create-pipeline` | `orchestra pipeline new` |
+| `orchestra update-pipeline` | `orchestra pipeline update` |
+| `orchestra delete-pipeline` | `orchestra pipeline delete` |
+| `orchestra run` | `orchestra pipeline run` |
+
+New code and documentation should prefer the noun/verb form.
 
 ---
 
-## validate
+## pipeline validate
 
 Validate a YAML file against the Orchestra API schema.
 
 ```bash
-orchestra validate path/to/pipeline.yaml
+orchestra pipeline validate path/to/pipeline.yaml
 # or
-orchestra-cli validate path/to/pipeline.yaml
+orchestra-cli pipeline validate path/to/pipeline.yaml
 ```
 
 Options
@@ -72,19 +92,19 @@ pipeline:
 
 ---
 
-## import
+## pipeline import
 
 Create (import) a pipeline in Orchestra by referencing a YAML file inside a git repository. The command infers your repository host/provider, default branch, and YAML path relative to the repo root.
 
 ```bash
 export ORCHESTRA_API_KEY=...  # required
 
-orchestra import \
+orchestra pipeline import \
   --alias my-pipeline \
   --path ./pipelines/pipeline.yaml \
   --working-branch my-feature-branch   # optional; defaults to current local branch
 # or
-orchestra-cli import -a my-pipeline -p ./pipelines/pipeline.yaml
+orchestra-cli pipeline import -a my-pipeline -p ./pipelines/pipeline.yaml
 ```
 
 Options
@@ -112,14 +132,14 @@ Common errors
 
 ---
 
-## create-pipeline
+## pipeline new
 
 Create an Orchestra-backed pipeline directly from a local YAML file.
 
 ```bash
 export ORCHESTRA_API_KEY=...
 
-orchestra create-pipeline \
+orchestra pipeline new \
   --alias my-pipeline \
   --path ./pipelines/pipeline.yaml \
   --publish            # optional, defaults to --no-publish
@@ -140,14 +160,14 @@ Behavior
 
 ---
 
-## fetch-pipelines
+## pipeline get
 
 Fetch the pipelines available to the current Orchestra API key.
 
 ```bash
 export ORCHESTRA_API_KEY=...
 
-orchestra fetch-pipelines
+orchestra pipeline get
 ```
 
 Behavior
@@ -158,14 +178,14 @@ Behavior
 
 ---
 
-## update-pipeline
+## pipeline update
 
 Update an existing Orchestra-backed pipeline from a local YAML file.
 
 ```bash
 export ORCHESTRA_API_KEY=...
 
-orchestra update-pipeline \
+orchestra pipeline update \
   --alias my-pipeline \
   --path ./pipelines/pipeline.yaml \
   --no-publish         # default
@@ -187,14 +207,14 @@ Behavior
 
 ---
 
-## delete-pipeline
+## pipeline delete
 
 Delete a pipeline by alias.
 
 ```bash
 export ORCHESTRA_API_KEY=...
 
-orchestra delete-pipeline --alias my-pipeline
+orchestra pipeline delete --alias my-pipeline
 ```
 
 Options
@@ -210,7 +230,7 @@ Behavior
 
 ---
 
-## run
+## pipeline run
 
 Start a pipeline run by alias. Optionally specify a branch and/or commit. By default, the command waits and polls the run status until completion.
 
@@ -218,13 +238,13 @@ Start a pipeline run by alias. Optionally specify a branch and/or commit. By def
 export ORCHESTRA_API_KEY=...
 
 # Start and wait for completion
-orchestra run --alias my-pipeline
+orchestra pipeline run --alias my-pipeline
 
 # Start without waiting (prints run id and exits)
-orchestra run -a my-pipeline --no-wait
+orchestra pipeline run -a my-pipeline --no-wait
 
 # Start for a specific branch/commit
-orchestra run -a my-pipeline -b feature/my-change -c 0123abc
+orchestra pipeline run -a my-pipeline -b feature/my-change -c 0123abc
 ```
 
 Options
@@ -253,16 +273,16 @@ Non-interactive usage
 
 ```bash
 # Validate a pipeline file
-orchestra validate ./examples/etl.yaml
+orchestra pipeline validate ./examples/etl.yaml
 
 # Import a pipeline and capture the created ID
-PIPELINE_ID=$(orchestra import -a finance-etl -p ./pipelines/etl.yaml)
+PIPELINE_ID=$(orchestra pipeline import -a finance-etl -p ./pipelines/etl.yaml)
 
 # Start a run and wait for completion
-orchestra run -a finance-etl
+orchestra pipeline run -a finance-etl
 
 # Start a run and exit immediately
-orchestra run -a finance-etl --no-wait
+orchestra pipeline run -a finance-etl --no-wait
 ```
 
 ---

--- a/orchestra_cli/src/AGENTS.md
+++ b/orchestra_cli/src/AGENTS.md
@@ -4,17 +4,31 @@ Command implementation guidance. See the root `AGENTS.md` for project overview, 
 
 ---
 
+## CLI Structure
+
+The CLI is organised as `orchestra <noun> <verb>`. The only noun today is `pipeline`, exposed as a Typer sub-app (`pipeline_app`) attached to the root `app` in `cli.py`. Verbs (`validate`, `import`, `new`, `update`, `get`, `delete`, `run`) are registered on `pipeline_app`.
+
+The previous flat command names (`validate`, `import`, `run`, `fetch-pipelines`, `create-pipeline`, `update-pipeline`, `delete-pipeline`) are also registered on the root `app` as **hidden** aliases (`hidden=True`) so existing scripts keep working. They do not appear in `--help` output.
+
 ## Adding a New CLI Command
 
 1. Create `orchestra_cli/src/<command_name>.py` with a single function decorated with Typer option/argument parameters.
-2. Register it in `orchestra_cli/src/cli.py`:
+2. Register it on the appropriate sub-app in `orchestra_cli/src/cli.py`:
 
    ```python
    from .<command_name> import <function_name>
-   app.command(name="<command_name>")(<function_name>)
+   pipeline_app.command(name="<verb>")(<function_name>)
    ```
 
-3. Add a corresponding `orchestra_cli/tests/test_<command_name>.py`.
+   If the command does not belong to an existing noun, add a new `typer.Typer()` sub-app and `app.add_typer(...)` it under the appropriate noun.
+
+3. If you need to preserve a legacy flat name, add a hidden top-level alias:
+
+   ```python
+   app.command(name="<legacy-name>", hidden=True)(<function_name>)
+   ```
+
+4. Add a corresponding `orchestra_cli/tests/test_<command_name>.py`.
 
 ---
 

--- a/orchestra_cli/src/README.md
+++ b/orchestra_cli/src/README.md
@@ -6,9 +6,13 @@ CLI command implementations. See `AGENTS.md` for conventions, patterns, and how 
 
 | File | Purpose |
 |------|---------|
-| `cli.py` | Typer app entry point; registers all commands |
-| `validate_pipeline.py` | `orchestra validate` — validates a YAML against the API schema |
-| `import_pipeline.py` | `orchestra import` — registers a pipeline from a git repo under an alias |
-| `run_pipeline.py` | `orchestra run` — starts a pipeline run; optionally polls until completion |
+| `cli.py` | Typer app entry point; defines the `pipeline` sub-app and registers all verbs (plus hidden legacy aliases) |
+| `validate_pipeline.py` | `orchestra pipeline validate` — validates a YAML against the API schema |
+| `import_pipeline.py` | `orchestra pipeline import` — registers a pipeline from a git repo under an alias |
+| `create_pipeline.py` | `orchestra pipeline new` — creates an Orchestra-backed pipeline from a local YAML |
+| `update_pipeline.py` | `orchestra pipeline update` — updates an Orchestra-backed pipeline from a local YAML |
+| `fetch_pipelines.py` | `orchestra pipeline get` — fetches pipelines visible to the current API key |
+| `delete_pipeline.py` | `orchestra pipeline delete` — deletes a pipeline by alias |
+| `run_pipeline.py` | `orchestra pipeline run` — starts a pipeline run; optionally polls until completion |
 
 Each command module exports a single public function registered in `cli.py`.

--- a/orchestra_cli/src/cli.py
+++ b/orchestra_cli/src/cli.py
@@ -10,11 +10,24 @@ from .validate_pipeline import validate
 
 app = typer.Typer(help="Orchestra CLI – perform operations with Orchestra locally.")
 
+pipeline_app = typer.Typer(help="Manage Orchestra pipelines (validate, import, run, ...).")
+app.add_typer(pipeline_app, name="pipeline")
 
-app.command(name="validate")(validate)
-app.command(name="import")(import_pipeline)
-app.command(name="run")(run_pipeline)
-app.command(name="fetch-pipelines")(fetch_pipelines)
-app.command(name="create-pipeline")(create_pipeline)
-app.command(name="update-pipeline")(update_pipeline)
-app.command(name="delete-pipeline")(delete_pipeline)
+pipeline_app.command(name="validate")(validate)
+pipeline_app.command(name="import")(import_pipeline)
+pipeline_app.command(name="new")(create_pipeline)
+pipeline_app.command(name="update")(update_pipeline)
+pipeline_app.command(name="get")(fetch_pipelines)
+pipeline_app.command(name="run")(run_pipeline)
+pipeline_app.command(name="delete")(delete_pipeline)
+
+# Legacy top-level aliases (hidden) - keep the old `orchestra <command>` syntax working
+# so existing scripts and CI pipelines do not break. Hidden from `--help` to keep the
+# advertised surface focused on the new noun/verb structure.
+app.command(name="validate", hidden=True)(validate)
+app.command(name="import", hidden=True)(import_pipeline)
+app.command(name="run", hidden=True)(run_pipeline)
+app.command(name="fetch-pipelines", hidden=True)(fetch_pipelines)
+app.command(name="create-pipeline", hidden=True)(create_pipeline)
+app.command(name="update-pipeline", hidden=True)(update_pipeline)
+app.command(name="delete-pipeline", hidden=True)(delete_pipeline)

--- a/orchestra_cli/tests/test_cli.py
+++ b/orchestra_cli/tests/test_cli.py
@@ -9,8 +9,40 @@ def test_help():
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0
     assert "Orchestra CLI" in result.output
-    assert "validate" in result.output
-    assert "fetch-pipelines" in result.output
-    assert "create-pipeline" in result.output
-    assert "delete-pipeline" in result.output
-    assert "update-pipeline" in result.output
+    assert "pipeline" in result.output
+
+
+def test_pipeline_help_lists_verbs():
+    result = runner.invoke(app, ["pipeline", "--help"])
+    assert result.exit_code == 0
+    for verb in ("validate", "import", "new", "update", "get", "run", "delete"):
+        assert verb in result.output
+
+
+def test_top_level_help_hides_legacy_aliases():
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    for legacy in (
+        "fetch-pipelines",
+        "create-pipeline",
+        "update-pipeline",
+        "delete-pipeline",
+    ):
+        assert legacy not in result.output
+
+
+def test_legacy_aliases_still_invokable():
+    # Each legacy alias is registered (hidden) so existing scripts keep working.
+    # Invoking with --help is a cheap way to confirm the command exists without
+    # exercising its full code path (covered in command-specific test files).
+    for alias in (
+        "validate",
+        "import",
+        "run",
+        "fetch-pipelines",
+        "create-pipeline",
+        "update-pipeline",
+        "delete-pipeline",
+    ):
+        result = runner.invoke(app, [alias, "--help"])
+        assert result.exit_code == 0, f"Legacy alias '{alias}' is not registered"

--- a/orchestra_cli/tests/test_create_pipeline.py
+++ b/orchestra_cli/tests/test_create_pipeline.py
@@ -38,7 +38,7 @@ def test_create_success_default_no_publish(tmp_path: Path, httpx_mock: HTTPXMock
         },
     )
 
-    result = runner.invoke(app, ["create-pipeline", "--alias", "demo", "--path", str(yaml_file)])
+    result = runner.invoke(app, ["pipeline", "new", "--alias", "demo", "--path", str(yaml_file)])
     assert result.exit_code == 0
     assert "created successfully" in result.output
     assert "https://app.getorchestra.io/pipelines/pipeline-id/edit" in result.output
@@ -81,7 +81,7 @@ def test_create_missing_api_key(monkeypatch, tmp_path: Path):
     yaml_file.write_text("name: demo\n")
 
     monkeypatch.delenv("ORCHESTRA_API_KEY", raising=False)
-    result = runner.invoke(app, ["create-pipeline", "--alias", "demo", "--path", str(yaml_file)])
+    result = runner.invoke(app, ["pipeline", "new", "--alias", "demo", "--path", str(yaml_file)])
     assert result.exit_code == 1
     assert "ORCHESTRA_API_KEY is not set" in result.output
 
@@ -90,7 +90,7 @@ def test_create_invalid_yaml(tmp_path: Path):
     bad = tmp_path / "bad.yaml"
     bad.write_text("name: [oops\n")
 
-    result = runner.invoke(app, ["create-pipeline", "--alias", "demo", "--path", str(bad)])
+    result = runner.invoke(app, ["pipeline", "new", "--alias", "demo", "--path", str(bad)])
     assert result.exit_code == 1
     assert "Invalid YAML" in result.output
 
@@ -106,7 +106,7 @@ def test_create_schema_validation_error(tmp_path: Path, httpx_mock: HTTPXMock):
         status_code=400,
     )
 
-    result = runner.invoke(app, ["create-pipeline", "--alias", "demo", "--path", str(yaml_file)])
+    result = runner.invoke(app, ["pipeline", "new", "--alias", "demo", "--path", str(yaml_file)])
     assert result.exit_code == 1
     assert "Validation failed" in result.output
 
@@ -128,7 +128,7 @@ def test_create_api_error(tmp_path: Path, httpx_mock: HTTPXMock):
         status_code=400,
     )
 
-    result = runner.invoke(app, ["create-pipeline", "--alias", "demo", "--path", str(yaml_file)])
+    result = runner.invoke(app, ["pipeline", "new", "--alias", "demo", "--path", str(yaml_file)])
     assert result.exit_code == 1
     assert "Create failed" in result.output
 
@@ -150,7 +150,7 @@ def test_create_success_without_pipeline_id_fails(tmp_path: Path, httpx_mock: HT
         status_code=201,
     )
 
-    result = runner.invoke(app, ["create-pipeline", "--alias", "demo", "--path", str(yaml_file)])
+    result = runner.invoke(app, ["pipeline", "new", "--alias", "demo", "--path", str(yaml_file)])
     assert result.exit_code == 1
     assert "success response did not include pipeline id" in result.output
 
@@ -172,6 +172,6 @@ def test_create_success_with_invalid_json_fails(tmp_path: Path, httpx_mock: HTTP
         status_code=201,
     )
 
-    result = runner.invoke(app, ["create-pipeline", "--alias", "demo", "--path", str(yaml_file)])
+    result = runner.invoke(app, ["pipeline", "new", "--alias", "demo", "--path", str(yaml_file)])
     assert result.exit_code == 1
     assert "success response was not valid JSON" in result.output

--- a/orchestra_cli/tests/test_delete_pipeline.py
+++ b/orchestra_cli/tests/test_delete_pipeline.py
@@ -24,7 +24,7 @@ def test_delete_success(httpx_mock: HTTPXMock):
         status_code=204,
     )
 
-    result = runner.invoke(app, ["delete-pipeline", "--alias", alias])
+    result = runner.invoke(app, ["pipeline", "delete", "--alias", alias])
 
     assert result.exit_code == 0
     assert "deleted successfully" in result.output
@@ -39,7 +39,7 @@ def test_delete_uuid_like_alias_uses_alias_path(httpx_mock: HTTPXMock):
         status_code=204,
     )
 
-    result = runner.invoke(app, ["delete-pipeline", "--alias", alias])
+    result = runner.invoke(app, ["pipeline", "delete", "--alias", alias])
 
     assert result.exit_code == 0
     assert "deleted successfully" in result.output
@@ -48,7 +48,7 @@ def test_delete_uuid_like_alias_uses_alias_path(httpx_mock: HTTPXMock):
 def test_delete_missing_api_key(monkeypatch):
     monkeypatch.delenv("ORCHESTRA_API_KEY", raising=False)
 
-    result = runner.invoke(app, ["delete-pipeline", "--alias", "demo"])
+    result = runner.invoke(app, ["pipeline", "delete", "--alias", "demo"])
 
     assert result.exit_code == 1
     assert "ORCHESTRA_API_KEY is not set" in result.output
@@ -60,7 +60,7 @@ def test_delete_http_request_failure(monkeypatch):
 
     monkeypatch.setattr(httpx, "delete", raise_timeout)
 
-    result = runner.invoke(app, ["delete-pipeline", "--alias", "demo"])
+    result = runner.invoke(app, ["pipeline", "delete", "--alias", "demo"])
 
     assert result.exit_code == 1
     assert "HTTP request failed" in result.output
@@ -75,7 +75,7 @@ def test_delete_api_error(httpx_mock: HTTPXMock):
         status_code=404,
     )
 
-    result = runner.invoke(app, ["delete-pipeline", "--alias", "demo"])
+    result = runner.invoke(app, ["pipeline", "delete", "--alias", "demo"])
 
     assert result.exit_code == 1
     assert "Delete failed with status 404" in result.output

--- a/orchestra_cli/tests/test_fetch_pipelines.py
+++ b/orchestra_cli/tests/test_fetch_pipelines.py
@@ -32,7 +32,7 @@ def test_fetch_pipelines_success(httpx_mock: HTTPXMock):
         match_headers={"Authorization": "Bearer fake-key"},
     )
 
-    result = runner.invoke(app, ["fetch-pipelines"])
+    result = runner.invoke(app, ["pipeline", "get"])
 
     assert result.exit_code == 0
     assert result.output == f"{json.dumps(pipelines, indent=2)}\n"
@@ -41,7 +41,7 @@ def test_fetch_pipelines_success(httpx_mock: HTTPXMock):
 def test_fetch_pipelines_missing_api_key(monkeypatch):
     monkeypatch.delenv("ORCHESTRA_API_KEY", raising=False)
 
-    result = runner.invoke(app, ["fetch-pipelines"])
+    result = runner.invoke(app, ["pipeline", "get"])
 
     assert result.exit_code == 1
     assert "ORCHESTRA_API_KEY is not set" in result.output
@@ -56,7 +56,7 @@ def test_fetch_pipelines_api_error(httpx_mock: HTTPXMock):
         match_headers={"Authorization": "Bearer fake-key"},
     )
 
-    result = runner.invoke(app, ["fetch-pipelines"])
+    result = runner.invoke(app, ["pipeline", "get"])
 
     assert result.exit_code == 1
     assert "Fetch pipelines failed with status 403" in result.output
@@ -72,7 +72,7 @@ def test_fetch_pipelines_invalid_success_json(httpx_mock: HTTPXMock):
         match_headers={"Authorization": "Bearer fake-key"},
     )
 
-    result = runner.invoke(app, ["fetch-pipelines"])
+    result = runner.invoke(app, ["pipeline", "get"])
 
     assert result.exit_code == 1
     assert "success response was not valid JSON" in result.output

--- a/orchestra_cli/tests/test_import_pipeline.py
+++ b/orchestra_cli/tests/test_import_pipeline.py
@@ -93,7 +93,7 @@ def test_import_success(
     monkeypatch.setattr(subprocess, "run", make_git_subprocess_mock(mapping))
 
     # Act
-    result = runner.invoke(app, ["import", "--alias", "demo", "--path", str(yaml_file)])
+    result = runner.invoke(app, ["pipeline", "import", "--alias", "demo", "--path", str(yaml_file)])
 
     # Assert
     assert result.exit_code == 0
@@ -107,7 +107,7 @@ def test_import_success(
 def test_import_invalid_yaml(tmp_path: Path):
     bad = tmp_path / "bad.yaml"
     bad.write_text("name: [oops\n")
-    result = runner.invoke(app, ["import", "--alias", "demo", "--path", str(bad)])
+    result = runner.invoke(app, ["pipeline", "import", "--alias", "demo", "--path", str(bad)])
     assert result.exit_code == 1
     assert "Invalid YAML" in result.output
 
@@ -123,7 +123,7 @@ def test_import_schema_validation_error(tmp_path: Path, httpx_mock: HTTPXMock):
         status_code=400,
     )
 
-    result = runner.invoke(app, ["import", "--alias", "demo", "--path", str(good)])
+    result = runner.invoke(app, ["pipeline", "import", "--alias", "demo", "--path", str(good)])
     assert result.exit_code == 1
     assert "Validation failed" in result.output
 
@@ -159,7 +159,7 @@ def test_import_api_error(monkeypatch, tmp_path: Path, httpx_mock: HTTPXMock):
 
     monkeypatch.setattr(subprocess, "run", make_git_subprocess_mock(mapping))
 
-    result = runner.invoke(app, ["import", "--alias", "demo", "--path", str(yaml_file)])
+    result = runner.invoke(app, ["pipeline", "import", "--alias", "demo", "--path", str(yaml_file)])
     assert result.exit_code == 1
     assert "Import failed" in result.output
 
@@ -182,7 +182,7 @@ def test_not_a_git_repo(monkeypatch, tmp_path: Path, httpx_mock: HTTPXMock):
     }
     monkeypatch.setattr(subprocess, "run", make_git_subprocess_mock(mapping))
 
-    result = runner.invoke(app, ["import", "--alias", "demo", "--path", str(yaml_file)])
+    result = runner.invoke(app, ["pipeline", "import", "--alias", "demo", "--path", str(yaml_file)])
     assert result.exit_code == 1
     assert "Not a git repository" in result.output
 
@@ -210,7 +210,7 @@ def test_missing_repo_or_branch(monkeypatch, tmp_path: Path, httpx_mock: HTTPXMo
     }
     monkeypatch.setattr(subprocess, "run", make_git_subprocess_mock(mapping))
 
-    result = runner.invoke(app, ["import", "--alias", "demo", "--path", str(f)])
+    result = runner.invoke(app, ["pipeline", "import", "--alias", "demo", "--path", str(f)])
     assert result.exit_code == 1
     assert "Could not detect repository URL from git" in result.output
 
@@ -257,7 +257,7 @@ def test_warnings_printed(monkeypatch, tmp_path: Path, httpx_mock: HTTPXMock):
 
     monkeypatch.setattr(subprocess, "run", make_git_subprocess_mock(mapping))
 
-    result = runner.invoke(app, ["import", "--alias", "demo", "--path", str(f)])
+    result = runner.invoke(app, ["pipeline", "import", "--alias", "demo", "--path", str(f)])
     assert result.exit_code == 0
     assert "⚠ Uncommitted changes" in result.output
     assert "Local branch SHA does not match remote branch SHA" in result.output

--- a/orchestra_cli/tests/test_run_pipeline.py
+++ b/orchestra_cli/tests/test_run_pipeline.py
@@ -38,7 +38,7 @@ def test_run_success_simple(httpx_mock: HTTPXMock, monkeypatch, tmp_path: Path):
         status_code=200,
     )
 
-    result = runner.invoke(app, ["run", "--alias", "demo", "--no-wait"])
+    result = runner.invoke(app, ["pipeline", "run", "--alias", "demo", "--no-wait"])
     assert result.exit_code == 0
     assert (
         result.output.strip()
@@ -69,6 +69,7 @@ def test_run_with_branch_commit(httpx_mock: HTTPXMock, monkeypatch, tmp_path: Pa
     result = runner.invoke(
         app,
         [
+            "pipeline",
             "run",
             "--alias",
             "demo",
@@ -109,7 +110,7 @@ def test_run_warnings_prompt(httpx_mock: HTTPXMock, monkeypatch, tmp_path: Path)
     )
 
     # Simulate pressing Enter
-    result = runner.invoke(app, ["run", "--alias", "demo", "--no-wait"], input="\n")
+    result = runner.invoke(app, ["pipeline", "run", "--alias", "demo", "--no-wait"], input="\n")
     assert result.exit_code == 0
     assert "⚠ Uncommitted changes" in result.output
     assert "Local branch SHA does not match remote branch SHA" in result.output
@@ -138,7 +139,7 @@ def test_run_api_error(httpx_mock: HTTPXMock, monkeypatch, tmp_path: Path):
         status_code=400,
     )
 
-    result = runner.invoke(app, ["run", "--alias", "demo", "--no-wait"])
+    result = runner.invoke(app, ["pipeline", "run", "--alias", "demo", "--no-wait"])
     assert result.exit_code == 1
     assert "Run failed" in result.output
 
@@ -179,7 +180,7 @@ def test_run_wait_success(httpx_mock: HTTPXMock, monkeypatch, tmp_path: Path):
         status_code=200,
     )
 
-    result = runner.invoke(app, ["run", "--alias", "demo", "--wait"])
+    result = runner.invoke(app, ["pipeline", "run", "--alias", "demo", "--wait"])
     assert result.exit_code == 0
     # Last printed line should be the run id
     assert result.output.strip().splitlines()[0] == "Starting pipeline (alias: demo)"
@@ -224,7 +225,7 @@ def test_run_wait_failed(httpx_mock: HTTPXMock, monkeypatch, tmp_path: Path):
         status_code=200,
     )
 
-    result = runner.invoke(app, ["run", "--alias", "demo", "--wait"])
+    result = runner.invoke(app, ["pipeline", "run", "--alias", "demo", "--wait"])
     assert result.exit_code == 1
     assert "Invalid status value: RUNNING" not in result.output
     assert "status FAILED" in result.output
@@ -257,6 +258,6 @@ def test_run_wait_warning(httpx_mock: HTTPXMock, monkeypatch, tmp_path: Path):
         status_code=200,
     )
 
-    result = runner.invoke(app, ["run", "--alias", "demo", "--wait"])
+    result = runner.invoke(app, ["pipeline", "run", "--alias", "demo", "--wait"])
     assert result.exit_code == 0
     assert result.output.strip().splitlines()[-1] == "run-warn"

--- a/orchestra_cli/tests/test_update_pipeline.py
+++ b/orchestra_cli/tests/test_update_pipeline.py
@@ -37,7 +37,7 @@ def test_update_success_default_no_publish(tmp_path: Path, httpx_mock: HTTPXMock
         },
     )
 
-    result = runner.invoke(app, ["update-pipeline", "--alias", "demo", "--path", str(yaml_file)])
+    result = runner.invoke(app, ["pipeline", "update", "--alias", "demo", "--path", str(yaml_file)])
     assert result.exit_code == 0
     assert "updated successfully" in result.output
     assert "https://app.getorchestra.io/pipelines/pipeline-id/edit" in result.output
@@ -79,7 +79,7 @@ def test_update_missing_api_key(monkeypatch, tmp_path: Path):
     yaml_file.write_text("name: demo\n")
 
     monkeypatch.delenv("ORCHESTRA_API_KEY", raising=False)
-    result = runner.invoke(app, ["update-pipeline", "--alias", "demo", "--path", str(yaml_file)])
+    result = runner.invoke(app, ["pipeline", "update", "--alias", "demo", "--path", str(yaml_file)])
     assert result.exit_code == 1
     assert "ORCHESTRA_API_KEY is not set" in result.output
 
@@ -88,7 +88,7 @@ def test_update_invalid_yaml(tmp_path: Path):
     bad = tmp_path / "bad.yaml"
     bad.write_text("name: [oops\n")
 
-    result = runner.invoke(app, ["update-pipeline", "--alias", "demo", "--path", str(bad)])
+    result = runner.invoke(app, ["pipeline", "update", "--alias", "demo", "--path", str(bad)])
     assert result.exit_code == 1
     assert "Invalid YAML" in result.output
 
@@ -104,7 +104,7 @@ def test_update_schema_validation_error(tmp_path: Path, httpx_mock: HTTPXMock):
         status_code=400,
     )
 
-    result = runner.invoke(app, ["update-pipeline", "--alias", "demo", "--path", str(yaml_file)])
+    result = runner.invoke(app, ["pipeline", "update", "--alias", "demo", "--path", str(yaml_file)])
     assert result.exit_code == 1
     assert "Validation failed" in result.output
 
@@ -126,7 +126,7 @@ def test_update_api_error_orchestra_backed_only(tmp_path: Path, httpx_mock: HTTP
         status_code=400,
     )
 
-    result = runner.invoke(app, ["update-pipeline", "--alias", "demo", "--path", str(yaml_file)])
+    result = runner.invoke(app, ["pipeline", "update", "--alias", "demo", "--path", str(yaml_file)])
     assert result.exit_code == 1
     assert "Update failed" in result.output
     assert "Only orchestra-backed pipelines can be updated via this endpoint." in result.output
@@ -149,7 +149,7 @@ def test_update_success_without_pipeline_id_fails(tmp_path: Path, httpx_mock: HT
         status_code=200,
     )
 
-    result = runner.invoke(app, ["update-pipeline", "--alias", "demo", "--path", str(yaml_file)])
+    result = runner.invoke(app, ["pipeline", "update", "--alias", "demo", "--path", str(yaml_file)])
     assert result.exit_code == 1
     assert "success response did not include pipeline id" in result.output
 
@@ -171,6 +171,6 @@ def test_update_success_with_invalid_json_fails(tmp_path: Path, httpx_mock: HTTP
         status_code=200,
     )
 
-    result = runner.invoke(app, ["update-pipeline", "--alias", "demo", "--path", str(yaml_file)])
+    result = runner.invoke(app, ["pipeline", "update", "--alias", "demo", "--path", str(yaml_file)])
     assert result.exit_code == 1
     assert "success response was not valid JSON" in result.output

--- a/orchestra_cli/tests/test_validate_pipeline.py
+++ b/orchestra_cli/tests/test_validate_pipeline.py
@@ -6,6 +6,6 @@ runner = CliRunner()
 
 
 def test_validate_missing_file():
-    result = runner.invoke(app, ["validate", "not_a_file.yaml"])
+    result = runner.invoke(app, ["pipeline", "validate", "not_a_file.yaml"])
     assert result.exit_code == 1
     assert "File not found" in result.output


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Objective
Make the CLI cleaner and easier to use with a `noun verb` command shape.

## Changes
- Group existing commands under an `orchestra pipeline <verb>` Typer sub-app: `validate`, `import`, `new`, `update`, `get`, `delete`, `run`.
- Keep all previous flat command names as hidden top-level aliases so existing scripts keep working without changes.
- Update tests and docs to use the new canonical form; add explicit test coverage that legacy aliases still resolve.

## Testing
Unit tested (`make test` — lint, type-check, format, and 50 pytest tests all pass) and verified `--help` output for both the new and legacy command surfaces.

## Checklist
- [x] Verified these changes are backwards compatible (db migrations, model updates)

## Additional Notes
Legacy command names are registered with `hidden=True` so they no longer appear in `--help`, keeping the advertised surface focused on the new structure while remaining invokable.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a6a8fd8-7d84-445b-9962-ba16a608a4e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a6a8fd8-7d84-445b-9962-ba16a608a4e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

