### PR TITLE
Clarify unsupported pipeline ID selector message

### DIFF
--- a/orchestra_cli/tests/test_pipeline_selector.py
+++ b/orchestra_cli/tests/test_pipeline_selector.py
@@ -64,7 +64,7 @@ def test_generate_alias_from_path_slugifies_filename():
     assert generate_alias_from_path(Path("My Pipeline.yaml")) == "my-pipeline"
 
 
-def test_pipeline_id_can_be_disallowed():
+def test_pipeline_id_can_be_disallowed(capsys):
     with pytest.raises(typer.Exit):
         resolve_pipeline_selector(
             alias=None,
@@ -72,6 +72,8 @@ def test_pipeline_id_can_be_disallowed():
             path=None,
             allow_pipeline_id=False,
         )
+
+    assert "Passing pipeline IDs is not supported for this command" in capsys.readouterr().out
 
 
 def test_create_command_does_not_accept_pipeline_id():

--- a/orchestra_cli/tests/test_pipeline_selector.py
+++ b/orchestra_cli/tests/test_pipeline_selector.py
@@ -73,7 +73,7 @@ def test_pipeline_id_can_be_disallowed(capsys):
             allow_pipeline_id=False,
         )
 
-    assert "--pipeline-id (-i) is not supported for this command" in capsys.readouterr().out
+    assert "Passing pipeline IDs is not supported for this command" in capsys.readouterr().out
 
 
 def test_create_command_does_not_accept_pipeline_id():

--- a/orchestra_cli/tests/test_pipeline_selector.py
+++ b/orchestra_cli/tests/test_pipeline_selector.py
@@ -73,7 +73,7 @@ def test_pipeline_id_can_be_disallowed(capsys):
             allow_pipeline_id=False,
         )
 
-    assert "Passing pipeline IDs is not supported for this command" in capsys.readouterr().out
+    assert "--pipeline-id (-i) is not supported for this command" in capsys.readouterr().out
 
 
 def test_create_command_does_not_accept_pipeline_id():

--- a/orchestra_cli/utils/pipeline_selector.py
+++ b/orchestra_cli/utils/pipeline_selector.py
@@ -68,7 +68,7 @@ def resolve_pipeline_selector(
 
     if pipeline_id:
         if not allow_pipeline_id:
-            typer.echo(red("Passing pipeline IDs is not supported for this command"))
+            typer.echo(red("--pipeline-id (-i) is not supported for this command"))
             raise typer.Exit(code=1)
         return PipelineSelector(pipeline_id=pipeline_id)
 

--- a/orchestra_cli/utils/pipeline_selector.py
+++ b/orchestra_cli/utils/pipeline_selector.py
@@ -68,7 +68,7 @@ def resolve_pipeline_selector(
 
     if pipeline_id:
         if not allow_pipeline_id:
-            typer.echo(red("--pipeline-id (-i) is not supported for this command"))
+            typer.echo(red("Passing pipeline IDs is not supported for this command"))
             raise typer.Exit(code=1)
         return PipelineSelector(pipeline_id=pipeline_id)
 

--- a/orchestra_cli/utils/pipeline_selector.py
+++ b/orchestra_cli/utils/pipeline_selector.py
@@ -68,7 +68,7 @@ def resolve_pipeline_selector(
 
     if pipeline_id:
         if not allow_pipeline_id:
-            typer.echo(red("--pipeline-id is not supported for this command"))
+            typer.echo(red("Passing pipeline IDs is not supported for this command"))
             raise typer.Exit(code=1)
         return PipelineSelector(pipeline_id=pipeline_id)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Objective
Clarify unsupported pipeline ID usage

## Changes
- Use generic pipeline ID wording when pipeline IDs are not accepted
- Cover the unsupported selector message in tests

## Testing
Selector tests, linting, formatting check, and type checking passed

## Checklist
- [ ] Verified these changes are backwards compatible (db migrations, model updates)

## Additional Notes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9d6b74b2-dfd3-4ad5-a088-22e6053ad8d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9d6b74b2-dfd3-4ad5-a088-22e6053ad8d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

