### PR TITLE
ENG-9786 Add pipeline get command

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ pipx install orchestra-cli
 
 ## Environment variables
 
-- `ORCHESTRA_API_KEY`: Required for actions that call the API (`pipeline import`, `pipeline new`, `pipeline update`, `pipeline delete`, `pipeline run`).
+- `ORCHESTRA_API_KEY`: Required for actions that call the API (`pipeline import`, `pipeline new`, `pipeline update`, `pipeline get`, `pipeline list`, `pipeline delete`, `pipeline run`).
 - `BASE_URL`: Optional. Override the default Orchestra host (`https://app.getorchestra.io`) for non‑production/testing.
 
 ## Command structure
@@ -31,7 +31,8 @@ Commands follow a `noun verb` shape. The current noun is `pipeline`:
 |---|---|
 | `orchestra pipeline validate <file>` | Validate a pipeline YAML locally against the Orchestra API schema. |
 | `orchestra pipeline import` | Register a pipeline YAML (from a git repo) with Orchestra under an alias. |
-| `orchestra pipeline get` | Fetch the pipelines visible to the current API key as JSON. |
+| `orchestra pipeline get` | Fetch one pipeline by path, alias, or pipeline ID. |
+| `orchestra pipeline list` | Fetch the pipelines visible to the current API key as JSON. |
 | `orchestra pipeline new` | Create an Orchestra-backed pipeline from a local YAML file. |
 | `orchestra pipeline update` | Update an existing Orchestra-backed pipeline from a local YAML file. |
 | `orchestra pipeline delete` | Delete an existing pipeline by alias. |
@@ -47,7 +48,7 @@ The previous flat command names continue to work as hidden top-level aliases so 
 |---|---|
 | `orchestra validate` | `orchestra pipeline validate` |
 | `orchestra import` | `orchestra pipeline import` |
-| `orchestra fetch-pipelines` | `orchestra pipeline get` |
+| `orchestra fetch-pipelines` | `orchestra pipeline list` |
 | `orchestra create-pipeline` | `orchestra pipeline new` |
 | `orchestra update-pipeline` | `orchestra pipeline update` |
 | `orchestra delete-pipeline` | `orchestra pipeline delete` |
@@ -162,12 +163,39 @@ Behavior
 
 ## pipeline get
 
+Fetch one pipeline using the shared pipeline selector flags.
+
+```bash
+export ORCHESTRA_API_KEY=...
+
+orchestra pipeline get --alias my-pipeline
+orchestra pipeline get --pipeline-id f374e795-50aa-4aeb-9936-d68d2b90475c
+orchestra pipeline get --path ./pipelines/pipeline.yaml
+```
+
+Options
+
+- `-a, --alias` (optional): Pipeline alias.
+- `-i, --pipeline-id` (optional): Pipeline ID.
+- `-p, --path` (optional): Path to pipeline YAML file. Inside a git repository, this resolves to `repository` and `yaml_path`; outside a git repository, the CLI prompts to use a generated alias.
+
+Behavior
+
+- Resolves the selector using the shared rules: alias first, then pipeline ID, then path.
+- Sends `GET /api/engine/public/pipeline` with the resolved selector.
+- Prints the returned pipeline metadata in a labeled, human-readable format.
+- Exit codes: `0` on success, `1` on failure.
+
+---
+
+## pipeline list
+
 Fetch the pipelines available to the current Orchestra API key.
 
 ```bash
 export ORCHESTRA_API_KEY=...
 
-orchestra pipeline get
+orchestra pipeline list
 ```
 
 Behavior

--- a/orchestra_cli/src/README.md
+++ b/orchestra_cli/src/README.md
@@ -11,7 +11,8 @@ CLI command implementations. See `AGENTS.md` for conventions, patterns, and how 
 | `import_pipeline.py` | `orchestra pipeline import` — registers a pipeline from a git repo under an alias |
 | `create_pipeline.py` | `orchestra pipeline new` — creates an Orchestra-backed pipeline from a local YAML |
 | `update_pipeline.py` | `orchestra pipeline update` — updates an Orchestra-backed pipeline from a local YAML |
-| `fetch_pipelines.py` | `orchestra pipeline get` — fetches pipelines visible to the current API key |
+| `get_pipeline.py` | `orchestra pipeline get` — fetches one pipeline by selector |
+| `fetch_pipelines.py` | `orchestra pipeline list` — fetches pipelines visible to the current API key |
 | `delete_pipeline.py` | `orchestra pipeline delete` — deletes a pipeline by alias |
 | `run_pipeline.py` | `orchestra pipeline run` — starts a pipeline run; optionally polls until completion |
 

--- a/orchestra_cli/src/cli.py
+++ b/orchestra_cli/src/cli.py
@@ -2,7 +2,8 @@ import typer
 
 from .create_pipeline import create_pipeline
 from .delete_pipeline import delete_pipeline
-from .fetch_pipelines import fetch_pipelines, get_pipeline
+from .fetch_pipelines import fetch_pipelines
+from .get_pipeline import get_pipeline
 from .import_pipeline import import_pipeline
 from .run_pipeline import run_pipeline
 from .update_pipeline import update_pipeline

--- a/orchestra_cli/src/fetch_pipelines.py
+++ b/orchestra_cli/src/fetch_pipelines.py
@@ -1,5 +1,4 @@
 import json
-from pathlib import Path
 
 import httpx
 import typer
@@ -10,47 +9,8 @@ from ..utils.api import (
     request_or_exit,
     require_api_key,
 )
-from ..utils.constants import get_api_url, get_pipeline_url
-from ..utils.pipeline_selector import (
-    pipeline_alias_option,
-    pipeline_id_option,
-    pipeline_path_option,
-    resolve_pipeline_selector,
-)
+from ..utils.constants import get_api_url
 from ..utils.styling import indent_message, red, yellow
-
-
-def get_pipeline(
-    path: Path | None = pipeline_path_option(),
-    alias: str | None = pipeline_alias_option(),
-    pipeline_id: str | None = pipeline_id_option(),
-):
-    """
-    Fetch one pipeline using the shared selector model.
-    """
-    api_key = require_api_key()
-    selector = resolve_pipeline_selector(alias, pipeline_id, path)
-
-    response = request_or_exit(
-        httpx.get,
-        get_pipeline_url(),
-        params=selector.to_payload(),
-        timeout=30,
-        headers=auth_headers(api_key),
-    )
-
-    if response.status_code == 200:
-        try:
-            pipeline = response.json()
-        except Exception:
-            typer.echo(red("❌ Get pipeline failed: success response was not valid JSON"))
-            typer.echo(yellow(indent_message(response.text)))
-            raise typer.Exit(code=1)
-
-        typer.echo(json.dumps(pipeline, indent=2))
-        raise typer.Exit(code=0)
-
-    fail_with_response("Get pipeline", response)
 
 
 def fetch_pipelines():

--- a/orchestra_cli/src/get_pipeline.py
+++ b/orchestra_cli/src/get_pipeline.py
@@ -21,7 +21,6 @@ from ..utils.pipeline_selector import (
 )
 from ..utils.styling import indent_message, red, yellow
 
-
 _PREFERRED_FIELD_ORDER = (
     "id",
     "pipeline_id",

--- a/orchestra_cli/src/get_pipeline.py
+++ b/orchestra_cli/src/get_pipeline.py
@@ -121,13 +121,10 @@ def _format_value(value: object) -> str:
 
 def _humanize_key(key: str) -> str:
     words = re.sub(r"(?<!^)(?=[A-Z])", " ", key).replace("_", " ").replace("-", " ")
-    label = words.title()
     replacements = {
-        "Api": "API",
-        "Id": "ID",
-        "Url": "URL",
-        "Yaml": "YAML",
+        "api": "API",
+        "id": "ID",
+        "url": "URL",
+        "yaml": "YAML",
     }
-    for old, new in replacements.items():
-        label = label.replace(old, new)
-    return label
+    return " ".join(replacements.get(word.lower(), word.title()) for word in words.split())

--- a/orchestra_cli/src/get_pipeline.py
+++ b/orchestra_cli/src/get_pipeline.py
@@ -1,0 +1,134 @@
+import json
+import re
+from pathlib import Path
+from typing import cast
+
+import httpx
+import typer
+
+from ..utils.api import (
+    auth_headers,
+    fail_with_response,
+    request_or_exit,
+    require_api_key,
+)
+from ..utils.constants import get_pipeline_url
+from ..utils.pipeline_selector import (
+    pipeline_alias_option,
+    pipeline_id_option,
+    pipeline_path_option,
+    resolve_pipeline_selector,
+)
+from ..utils.styling import indent_message, red, yellow
+
+
+_PREFERRED_FIELD_ORDER = (
+    "id",
+    "pipeline_id",
+    "alias",
+    "name",
+    "description",
+    "repository",
+    "yaml_path",
+    "storage_provider",
+    "published",
+    "latestRunStatus",
+    "latest_run_status",
+    "latestRunId",
+    "latest_run_id",
+    "createdAt",
+    "created_at",
+    "updatedAt",
+    "updated_at",
+)
+
+
+def get_pipeline(
+    path: Path | None = pipeline_path_option(),
+    alias: str | None = pipeline_alias_option(),
+    pipeline_id: str | None = pipeline_id_option(),
+):
+    """
+    Fetch one pipeline using the shared selector model.
+    """
+    api_key = require_api_key()
+    selector = resolve_pipeline_selector(alias, pipeline_id, path)
+
+    response = request_or_exit(
+        httpx.get,
+        get_pipeline_url(),
+        params=selector.to_payload(),
+        timeout=30,
+        headers=auth_headers(api_key),
+    )
+
+    if response.status_code == 200:
+        try:
+            body = response.json()
+        except Exception:
+            typer.echo(red("❌ Get pipeline failed: success response was not valid JSON"))
+            typer.echo(yellow(indent_message(response.text)))
+            raise typer.Exit(code=1)
+
+        if not isinstance(body, dict):
+            typer.echo(red("❌ Get pipeline failed: success response was not a JSON object"))
+            typer.echo(yellow(indent_message(json.dumps(body, indent=2))))
+            raise typer.Exit(code=1)
+
+        pipeline = cast(dict[str, object], body)
+        typer.echo(_format_pipeline_metadata(pipeline))
+        raise typer.Exit(code=0)
+
+    fail_with_response("Get pipeline", response)
+
+
+def _format_pipeline_metadata(pipeline: dict[str, object]) -> str:
+    lines: list[str] = []
+    emitted = set()
+
+    for key in _ordered_keys(pipeline):
+        value = pipeline[key]
+        if value is None:
+            continue
+
+        label = _humanize_key(key)
+        formatted_value = _format_value(value)
+        if "\n" in formatted_value:
+            lines.append(f"  {label}:")
+            lines.append(indent_message(formatted_value))
+        else:
+            lines.append(f"  {label}: {formatted_value}")
+        emitted.add(key)
+
+    if not emitted:
+        lines.append("  No metadata returned")
+
+    return "\n".join(["Pipeline", *lines])
+
+
+def _ordered_keys(pipeline: dict[str, object]) -> list[str]:
+    preferred_keys = [key for key in _PREFERRED_FIELD_ORDER if key in pipeline]
+    remaining_keys = sorted(key for key in pipeline if key not in _PREFERRED_FIELD_ORDER)
+    return [*preferred_keys, *remaining_keys]
+
+
+def _format_value(value: object) -> str:
+    if isinstance(value, bool):
+        return "yes" if value else "no"
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, indent=2)
+    return str(value)
+
+
+def _humanize_key(key: str) -> str:
+    words = re.sub(r"(?<!^)(?=[A-Z])", " ", key).replace("_", " ").replace("-", " ")
+    label = words.title()
+    replacements = {
+        "Api": "API",
+        "Id": "ID",
+        "Url": "URL",
+        "Yaml": "YAML",
+    }
+    for old, new in replacements.items():
+        label = label.replace(old, new)
+    return label

--- a/orchestra_cli/tests/test_fetch_pipelines.py
+++ b/orchestra_cli/tests/test_fetch_pipelines.py
@@ -15,34 +15,6 @@ def mock_env(monkeypatch):
     monkeypatch.setenv("BASE_URL", "")
 
 
-def test_get_pipeline_success_by_alias(httpx_mock: HTTPXMock):
-    pipeline = {
-        "id": "pipe-1",
-        "alias": "demo",
-        "name": "Demo pipeline",
-        "latestRunStatus": "SUCCEEDED",
-    }
-    httpx_mock.add_response(
-        method="GET",
-        url="https://app.getorchestra.io/api/engine/public/pipeline?alias=demo",
-        json=pipeline,
-        status_code=200,
-        match_headers={"Authorization": "Bearer fake-key"},
-    )
-
-    result = runner.invoke(app, ["pipeline", "get", "--alias", "demo"])
-
-    assert result.exit_code == 0
-    assert result.output == f"{json.dumps(pipeline, indent=2)}\n"
-
-
-def test_get_pipeline_requires_selector():
-    result = runner.invoke(app, ["pipeline", "get"])
-
-    assert result.exit_code == 1
-    assert "Provide one of --alias, --pipeline-id, or --path" in result.output
-
-
 def test_fetch_pipelines_legacy_success(httpx_mock: HTTPXMock):
     pipelines = [
         {
@@ -89,41 +61,3 @@ def test_list_pipelines_success(httpx_mock: HTTPXMock):
     assert result.output == f"{json.dumps(pipelines, indent=2)}\n"
 
 
-def test_get_pipeline_missing_api_key(monkeypatch):
-    monkeypatch.delenv("ORCHESTRA_API_KEY", raising=False)
-
-    result = runner.invoke(app, ["pipeline", "get", "--alias", "demo"])
-
-    assert result.exit_code == 1
-    assert "ORCHESTRA_API_KEY is not set" in result.output
-
-
-def test_get_pipeline_api_error(httpx_mock: HTTPXMock):
-    httpx_mock.add_response(
-        method="GET",
-        url="https://app.getorchestra.io/api/engine/public/pipeline?alias=demo",
-        json={"detail": "Forbidden"},
-        status_code=403,
-        match_headers={"Authorization": "Bearer fake-key"},
-    )
-
-    result = runner.invoke(app, ["pipeline", "get", "--alias", "demo"])
-
-    assert result.exit_code == 1
-    assert "Get pipeline failed with status 403" in result.output
-    assert "Forbidden" in result.output
-
-
-def test_get_pipeline_invalid_success_json(httpx_mock: HTTPXMock):
-    httpx_mock.add_response(
-        method="GET",
-        url="https://app.getorchestra.io/api/engine/public/pipeline?alias=demo",
-        text="ok",
-        status_code=200,
-        match_headers={"Authorization": "Bearer fake-key"},
-    )
-
-    result = runner.invoke(app, ["pipeline", "get", "--alias", "demo"])
-
-    assert result.exit_code == 1
-    assert "success response was not valid JSON" in result.output

--- a/orchestra_cli/tests/test_fetch_pipelines.py
+++ b/orchestra_cli/tests/test_fetch_pipelines.py
@@ -59,5 +59,3 @@ def test_list_pipelines_success(httpx_mock: HTTPXMock):
 
     assert result.exit_code == 0
     assert result.output == f"{json.dumps(pipelines, indent=2)}\n"
-
-

--- a/orchestra_cli/tests/test_get_pipeline.py
+++ b/orchestra_cli/tests/test_get_pipeline.py
@@ -1,0 +1,152 @@
+from pathlib import Path
+
+import httpx
+import pytest
+from pytest_httpx import HTTPXMock
+from typer.testing import CliRunner
+
+from orchestra_cli.src.cli import app
+from tests.conftest import make_git_subprocess_mock
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def mock_env(monkeypatch):
+    monkeypatch.setenv("ORCHESTRA_API_KEY", "fake-key")
+    monkeypatch.setenv("BASE_URL", "")
+
+
+def test_get_pipeline_success_by_alias(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(
+        method="GET",
+        url="https://app.getorchestra.io/api/engine/public/pipeline?alias=demo",
+        json={
+            "id": "pipe-1",
+            "alias": "demo",
+            "name": "Demo pipeline",
+            "latestRunStatus": "SUCCEEDED",
+        },
+        status_code=200,
+        match_headers={"Authorization": "Bearer fake-key"},
+    )
+
+    result = runner.invoke(app, ["pipeline", "get", "--alias", "demo"])
+
+    assert result.exit_code == 0
+    assert result.output == (
+        "Pipeline\n"
+        "  ID: pipe-1\n"
+        "  Alias: demo\n"
+        "  Name: Demo pipeline\n"
+        "  Latest Run Status: SUCCEEDED\n"
+    )
+
+
+def test_get_pipeline_success_by_pipeline_id(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(
+        method="GET",
+        url="https://app.getorchestra.io/api/engine/public/pipeline?pipeline_id=pipeline-id",
+        json={"id": "pipeline-id", "alias": "demo"},
+        status_code=200,
+        match_headers={"Authorization": "Bearer fake-key"},
+    )
+
+    result = runner.invoke(app, ["pipeline", "get", "--pipeline-id", "pipeline-id"])
+
+    assert result.exit_code == 0
+    assert "ID: pipeline-id" in result.output
+    assert "Alias: demo" in result.output
+
+
+def test_get_pipeline_success_by_path_inside_git(
+    httpx_mock: HTTPXMock,
+    monkeypatch,
+    tmp_path: Path,
+):
+    yaml_file = tmp_path / "pipe.yaml"
+    yaml_file.write_text("name: demo\n")
+    mapping = {
+        ("rev-parse", "--show-toplevel"): (0, str(tmp_path), ""),
+        ("remote", "get-url", "origin"): (0, "git@github.com:org/repo.git", ""),
+    }
+    import subprocess
+
+    monkeypatch.setattr(subprocess, "run", make_git_subprocess_mock(mapping))
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        assert dict(request.url.params.multi_items()) == {
+            "repository": "org/repo",
+            "yaml_path": "pipe.yaml",
+        }
+        assert request.headers["Authorization"] == "Bearer fake-key"
+        return httpx.Response(200, json={"id": "pipe-1", "repository": "org/repo"})
+
+    httpx_mock.add_callback(respond, method="GET")
+
+    result = runner.invoke(app, ["pipeline", "get", "--path", str(yaml_file)])
+
+    assert result.exit_code == 0
+    assert "Repository: org/repo" in result.output
+
+
+def test_get_pipeline_requires_selector():
+    result = runner.invoke(app, ["pipeline", "get"])
+
+    assert result.exit_code == 1
+    assert "Provide one of --alias, --pipeline-id, or --path" in result.output
+
+
+def test_get_pipeline_missing_api_key(monkeypatch):
+    monkeypatch.delenv("ORCHESTRA_API_KEY", raising=False)
+
+    result = runner.invoke(app, ["pipeline", "get", "--alias", "demo"])
+
+    assert result.exit_code == 1
+    assert "ORCHESTRA_API_KEY is not set" in result.output
+
+
+def test_get_pipeline_api_error(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(
+        method="GET",
+        url="https://app.getorchestra.io/api/engine/public/pipeline?alias=demo",
+        json={"detail": "Forbidden"},
+        status_code=403,
+        match_headers={"Authorization": "Bearer fake-key"},
+    )
+
+    result = runner.invoke(app, ["pipeline", "get", "--alias", "demo"])
+
+    assert result.exit_code == 1
+    assert "Get pipeline failed with status 403" in result.output
+    assert "Forbidden" in result.output
+
+
+def test_get_pipeline_invalid_success_json(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(
+        method="GET",
+        url="https://app.getorchestra.io/api/engine/public/pipeline?alias=demo",
+        text="ok",
+        status_code=200,
+        match_headers={"Authorization": "Bearer fake-key"},
+    )
+
+    result = runner.invoke(app, ["pipeline", "get", "--alias", "demo"])
+
+    assert result.exit_code == 1
+    assert "success response was not valid JSON" in result.output
+
+
+def test_get_pipeline_rejects_non_object_success_json(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(
+        method="GET",
+        url="https://app.getorchestra.io/api/engine/public/pipeline?alias=demo",
+        json=[],
+        status_code=200,
+        match_headers={"Authorization": "Bearer fake-key"},
+    )
+
+    result = runner.invoke(app, ["pipeline", "get", "--alias", "demo"])
+
+    assert result.exit_code == 1
+    assert "success response was not a JSON object" in result.output

--- a/orchestra_cli/tests/test_get_pipeline.py
+++ b/orchestra_cli/tests/test_get_pipeline.py
@@ -43,6 +43,33 @@ def test_get_pipeline_success_by_alias(httpx_mock: HTTPXMock):
     )
 
 
+def test_get_pipeline_humanizes_abbreviations_without_corrupting_words(
+    httpx_mock: HTTPXMock,
+):
+    httpx_mock.add_response(
+        method="GET",
+        url="https://app.getorchestra.io/api/engine/public/pipeline?alias=demo",
+        json={
+            "identity": "external-key",
+            "api_url": "https://example.com",
+            "idle_timeout": 30,
+            "yaml_path": "pipe.yaml",
+        },
+        status_code=200,
+        match_headers={"Authorization": "Bearer fake-key"},
+    )
+
+    result = runner.invoke(app, ["pipeline", "get", "--alias", "demo"])
+
+    assert result.exit_code == 0
+    assert "  Identity: external-key" in result.output
+    assert "  API URL: https://example.com" in result.output
+    assert "  Idle Timeout: 30" in result.output
+    assert "  YAML Path: pipe.yaml" in result.output
+    assert "IDentity" not in result.output
+    assert "IDle" not in result.output
+
+
 def test_get_pipeline_success_by_pipeline_id(httpx_mock: HTTPXMock):
     httpx_mock.add_response(
         method="GET",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Objective
Fetch a single pipeline from the CLI

## Changes
- Add selector-based single pipeline lookup
- Render pipeline metadata in a labeled format
- Keep pipeline listing on the list command
- Update command documentation
- Make metadata label abbreviation formatting word-aware

## Testing
Lint, type checking, formatting, and unit tests passed.

## Checklist
- [ ] Verified these changes are backwards compatible (db migrations, model updates)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b9d9987a-97f0-4dc8-a67a-a91bdd13da7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b9d9987a-97f0-4dc8-a67a-a91bdd13da7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

