### PR TITLE
ENG-9929 Confirm pipeline deletion

### DIFF
--- a/orchestra_cli/src/delete_pipeline.py
+++ b/orchestra_cli/src/delete_pipeline.py
@@ -16,7 +16,7 @@ from ..utils.pipeline_selector import (
     pipeline_path_option,
     resolve_pipeline_selector,
 )
-from ..utils.styling import green
+from ..utils.styling import green, yellow
 
 
 def delete_pipeline(
@@ -29,6 +29,10 @@ def delete_pipeline(
     """
     api_key = require_api_key()
     selector = resolve_pipeline_selector(alias, pipeline_id, path)
+
+    if not typer.confirm(f"Delete pipeline ({selector.display()})?"):
+        typer.echo(yellow("Deletion aborted"))
+        raise typer.Exit(code=1)
 
     response = request_or_exit(
         httpx.delete,

--- a/orchestra_cli/tests/test_delete_pipeline.py
+++ b/orchestra_cli/tests/test_delete_pipeline.py
@@ -24,9 +24,10 @@ def test_delete_success(httpx_mock: HTTPXMock):
         status_code=204,
     )
 
-    result = runner.invoke(app, ["pipeline", "delete", "--alias", alias])
+    result = runner.invoke(app, ["pipeline", "delete", "--alias", alias], input="y\n")
 
     assert result.exit_code == 0
+    assert "Delete pipeline (alias: demo)?" in result.output
     assert "deleted successfully" in result.output
 
 
@@ -39,7 +40,7 @@ def test_delete_uuid_like_alias_uses_alias_query(httpx_mock: HTTPXMock):
         status_code=204,
     )
 
-    result = runner.invoke(app, ["pipeline", "delete", "--alias", alias])
+    result = runner.invoke(app, ["pipeline", "delete", "--alias", alias], input="y\n")
 
     assert result.exit_code == 0
     assert "deleted successfully" in result.output
@@ -53,10 +54,31 @@ def test_delete_pipeline_id_uses_query_selector(httpx_mock: HTTPXMock):
         status_code=204,
     )
 
-    result = runner.invoke(app, ["pipeline", "delete", "--pipeline-id", "pipeline-id"])
+    result = runner.invoke(
+        app,
+        ["pipeline", "delete", "--pipeline-id", "pipeline-id"],
+        input="y\n",
+    )
 
     assert result.exit_code == 0
     assert "pipeline_id: pipeline-id" in result.output
+
+
+def test_delete_aborts_without_confirmation(monkeypatch):
+    delete_calls = []
+
+    def record_delete(*args, **kwargs):  # noqa: ARG001
+        delete_calls.append((args, kwargs))
+        return httpx.Response(status_code=204)
+
+    monkeypatch.setattr(httpx, "delete", record_delete)
+
+    result = runner.invoke(app, ["pipeline", "delete", "--alias", "demo"], input="n\n")
+
+    assert result.exit_code == 1
+    assert "Delete pipeline (alias: demo)?" in result.output
+    assert "Deletion aborted" in result.output
+    assert delete_calls == []
 
 
 def test_delete_requires_selector():
@@ -69,7 +91,7 @@ def test_delete_requires_selector():
 def test_delete_missing_api_key(monkeypatch):
     monkeypatch.delenv("ORCHESTRA_API_KEY", raising=False)
 
-    result = runner.invoke(app, ["pipeline", "delete", "--alias", "demo"])
+    result = runner.invoke(app, ["pipeline", "delete", "--alias", "demo"], input="y\n")
 
     assert result.exit_code == 1
     assert "ORCHESTRA_API_KEY is not set" in result.output
@@ -81,7 +103,7 @@ def test_delete_http_request_failure(monkeypatch):
 
     monkeypatch.setattr(httpx, "delete", raise_timeout)
 
-    result = runner.invoke(app, ["pipeline", "delete", "--alias", "demo"])
+    result = runner.invoke(app, ["pipeline", "delete", "--alias", "demo"], input="y\n")
 
     assert result.exit_code == 1
     assert "HTTP request failed" in result.output
@@ -96,7 +118,7 @@ def test_delete_api_error(httpx_mock: HTTPXMock):
         status_code=404,
     )
 
-    result = runner.invoke(app, ["pipeline", "delete", "--alias", "demo"])
+    result = runner.invoke(app, ["pipeline", "delete", "--alias", "demo"], input="y\n")
 
     assert result.exit_code == 1
     assert "Delete failed with status 404" in result.output


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Objective
Confirm destructive pipeline deletion

## Changes
- Added an explicit confirmation step before deleting a pipeline
- Kept selector-based delete requests unchanged after confirmation
- Covered confirmed and declined deletion paths in tests

## Testing
Lint, type checking, formatting, unit tests, and CLI abort smoke test passed.

## Checklist
- [x] Verified these changes are backwards compatible (db migrations, model updates)

## Additional Notes

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-9929](https://linear.app/getorchestra/issue/ENG-9929/confirm-pipeline-deletion)

<div><a href="https://cursor.com/agents/bc-fb394934-1a65-4a58-b17b-169a489a4159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb394934-1a65-4a58-b17b-169a489a4159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

