### PR TITLE
ENG-9930 Add default branch option to pipeline import

### DIFF
--- a/orchestra_cli/src/import_pipeline.py
+++ b/orchestra_cli/src/import_pipeline.py
@@ -97,7 +97,7 @@ def import_pipeline(
     if not repository_slug:
         typer.echo(red("Could not detect repository URL from git"))
         raise typer.Exit(code=1)
-    if default_branch is None:
+    if not default_branch:
         default_branch = _detect_default_branch(repo_root)
         if not default_branch:
             typer.echo(red("Could not detect default branch from git"))

--- a/orchestra_cli/src/import_pipeline.py
+++ b/orchestra_cli/src/import_pipeline.py
@@ -66,6 +66,11 @@ def _detect_storage_provider(repository_url: str | None) -> str:
 def import_pipeline(
     path: Path | None = pipeline_path_option("Path to pipeline YAML inside a git repository"),
     alias: str | None = pipeline_alias_option(),
+    default_branch: str | None = typer.Option(
+        None,
+        "--default-branch",
+        help="Default branch for the imported pipeline (defaults to the git remote default branch)",
+    ),
     working_branch: str | None = typer.Option(
         None,
         "--working-branch",
@@ -92,10 +97,11 @@ def import_pipeline(
     if not repository_slug:
         typer.echo(red("Could not detect repository URL from git"))
         raise typer.Exit(code=1)
-    default_branch = _detect_default_branch(repo_root)
-    if not default_branch:
-        typer.echo(red("Could not detect default branch from git"))
-        raise typer.Exit(code=1)
+    if default_branch is None:
+        default_branch = _detect_default_branch(repo_root)
+        if not default_branch:
+            typer.echo(red("Could not detect default branch from git"))
+            raise typer.Exit(code=1)
 
     # Determine working branch (explicit option or current branch)
     if working_branch is None:

--- a/orchestra_cli/tests/test_import_pipeline.py
+++ b/orchestra_cli/tests/test_import_pipeline.py
@@ -1,3 +1,4 @@
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -88,8 +89,6 @@ def test_import_success(
         ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"): (1, "", ""),
     }
 
-    import subprocess
-
     monkeypatch.setattr(subprocess, "run", make_git_subprocess_mock(mapping))
 
     # Act
@@ -146,8 +145,6 @@ def test_import_alias_is_optional(monkeypatch, tmp_path: Path, httpx_mock: HTTPX
         ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"): (1, "", ""),
     }
 
-    import subprocess
-
     monkeypatch.setattr(subprocess, "run", make_git_subprocess_mock(mapping))
 
     result = runner.invoke(app, ["pipeline", "import", "--path", str(yaml_file)])
@@ -190,8 +187,6 @@ def test_import_accepts_explicit_default_branch(monkeypatch, tmp_path: Path, htt
         ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"): (1, "", ""),
     }
 
-    import subprocess
-
     monkeypatch.setattr(subprocess, "run", make_git_subprocess_mock(mapping))
 
     result = runner.invoke(
@@ -205,6 +200,63 @@ def test_import_accepts_explicit_default_branch(monkeypatch, tmp_path: Path, htt
             str(yaml_file),
             "--default-branch",
             "trunk",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "imported successfully" in result.output
+
+
+def test_import_empty_default_branch_falls_back_to_git(
+    monkeypatch, tmp_path: Path, httpx_mock: HTTPXMock
+):
+    repo_root = tmp_path
+    yaml_file = repo_root / "pipe.yaml"
+    yaml_file.write_text("name: demo\nversion: 1\n")
+
+    httpx_mock.add_response(
+        method="POST",
+        url="https://app.getorchestra.io/api/engine/public/pipelines/schema",
+        json={"ok": True},
+        status_code=200,
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url="https://app.getorchestra.io/api/engine/public/pipelines/import",
+        json={"id": mock_pipeline_id},
+        status_code=201,
+        match_json={
+            "storage_provider": "GITHUB",
+            "repository": "org/repo",
+            "default_branch": "main",
+            "working_branch": "feature/import",
+            "yaml_path": "pipe.yaml",
+            "alias": "demo",
+        },
+    )
+
+    mapping = {
+        ("rev-parse", "--show-toplevel"): (0, str(repo_root), ""),
+        ("remote", "get-url", "origin"): (0, "git@github.com:org/repo.git", ""),
+        ("symbolic-ref", "refs/remotes/origin/HEAD"): (0, "refs/remotes/origin/main", ""),
+        ("rev-parse", "--abbrev-ref", "HEAD"): (0, "feature/import", ""),
+        ("status", "--porcelain"): (0, "", ""),
+        ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"): (1, "", ""),
+    }
+
+    monkeypatch.setattr(subprocess, "run", make_git_subprocess_mock(mapping))
+
+    result = runner.invoke(
+        app,
+        [
+            "pipeline",
+            "import",
+            "--alias",
+            "demo",
+            "--path",
+            str(yaml_file),
+            "--default-branch",
+            "",
         ],
     )
 
@@ -255,8 +307,6 @@ def test_import_api_error(monkeypatch, tmp_path: Path, httpx_mock: HTTPXMock):
         ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"): (1, "", ""),
     }
 
-    import subprocess
-
     monkeypatch.setattr(subprocess, "run", make_git_subprocess_mock(mapping))
 
     result = runner.invoke(app, ["pipeline", "import", "--alias", "demo", "--path", str(yaml_file)])
@@ -274,8 +324,6 @@ def test_not_a_git_repo(monkeypatch, tmp_path: Path, httpx_mock: HTTPXMock):
         json={"ok": True},
         status_code=200,
     )
-    import subprocess
-
     # rev-parse --show-toplevel fails
     mapping = {
         ("rev-parse", "--show-toplevel"): (1, "", "fatal: not a git repo"),
@@ -298,8 +346,6 @@ def test_missing_repo_or_branch(monkeypatch, tmp_path: Path, httpx_mock: HTTPXMo
         json={"ok": True},
         status_code=200,
     )
-    import subprocess
-
     # repo root ok, but cannot get remote url or default branch
     mapping = {
         ("rev-parse", "--show-toplevel"): (0, str(repo_root), ""),
@@ -340,8 +386,6 @@ def test_warnings_printed(monkeypatch, tmp_path: Path, httpx_mock: HTTPXMock):
             "alias": "demo",
         },
     )
-
-    import subprocess
 
     mapping = {
         ("rev-parse", "--show-toplevel"): (0, str(repo_root), ""),

--- a/orchestra_cli/tests/test_import_pipeline.py
+++ b/orchestra_cli/tests/test_import_pipeline.py
@@ -156,6 +156,62 @@ def test_import_alias_is_optional(monkeypatch, tmp_path: Path, httpx_mock: HTTPX
     assert "imported successfully" in result.output
 
 
+def test_import_accepts_explicit_default_branch(monkeypatch, tmp_path: Path, httpx_mock: HTTPXMock):
+    repo_root = tmp_path
+    yaml_file = repo_root / "pipe.yaml"
+    yaml_file.write_text("name: demo\nversion: 1\n")
+
+    httpx_mock.add_response(
+        method="POST",
+        url="https://app.getorchestra.io/api/engine/public/pipelines/schema",
+        json={"ok": True},
+        status_code=200,
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url="https://app.getorchestra.io/api/engine/public/pipelines/import",
+        json={"id": mock_pipeline_id},
+        status_code=201,
+        match_json={
+            "storage_provider": "GITHUB",
+            "repository": "org/repo",
+            "default_branch": "trunk",
+            "working_branch": "feature/import",
+            "yaml_path": "pipe.yaml",
+            "alias": "demo",
+        },
+    )
+
+    mapping = {
+        ("rev-parse", "--show-toplevel"): (0, str(repo_root), ""),
+        ("remote", "get-url", "origin"): (0, "git@github.com:org/repo.git", ""),
+        ("rev-parse", "--abbrev-ref", "HEAD"): (0, "feature/import", ""),
+        ("status", "--porcelain"): (0, "", ""),
+        ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"): (1, "", ""),
+    }
+
+    import subprocess
+
+    monkeypatch.setattr(subprocess, "run", make_git_subprocess_mock(mapping))
+
+    result = runner.invoke(
+        app,
+        [
+            "pipeline",
+            "import",
+            "--alias",
+            "demo",
+            "--path",
+            str(yaml_file),
+            "--default-branch",
+            "trunk",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "imported successfully" in result.output
+
+
 def test_import_schema_validation_error(tmp_path: Path, httpx_mock: HTTPXMock):
     good = tmp_path / "ok.yaml"
     good.write_text("name: ok\n")

--- a/orchestra_cli/tests/test_import_pipeline.py
+++ b/orchestra_cli/tests/test_import_pipeline.py
@@ -208,7 +208,9 @@ def test_import_accepts_explicit_default_branch(monkeypatch, tmp_path: Path, htt
 
 
 def test_import_empty_default_branch_falls_back_to_git(
-    monkeypatch, tmp_path: Path, httpx_mock: HTTPXMock
+    monkeypatch,
+    tmp_path: Path,
+    httpx_mock: HTTPXMock,
 ):
     repo_root = tmp_path
     yaml_file = repo_root / "pipe.yaml"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Objective
Allow pipeline imports to specify the default branch.

## Changes
- Added an optional default branch flag to pipeline import.
- Preserved git-based default branch detection when the flag is omitted or passed as an empty value.
- Moved import test dependencies to module scope.
- Covered the import request payload for explicit and fallback default branch usage.

## Testing
Lint, type checks, formatting checks, and unit tests pass.

## Checklist
- [x] Verified these changes are backwards compatible (db migrations, model updates)

## Additional Notes

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-9930](https://linear.app/getorchestra/issue/ENG-9930/require-import-default-branch)

<div><a href="https://cursor.com/agents/bc-d6de0221-5fe4-4e30-8545-e3bf21ce2d85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d6de0221-5fe4-4e30-8545-e3bf21ce2d85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

