### PR TITLE
[ENG-9931] Align pipeline update selector and git-backed flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ Options
 - `-i, --pipeline-id` (optional): Pipeline ID.
 - `-p, --path` (required): Path to pipeline YAML file.
 - `--publish/--no-publish` (optional, default `--no-publish`): Whether the pipeline is published.
+- `--force/--no-force` (optional, default `--no-force`): Skip interactive confirmation prompts when the CLI generates aliases or performs git-backed commit/branch fallback actions.
 
 Behavior
 

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Behavior
 
 ## pipeline update
 
-Update an existing Orchestra-backed pipeline from a local YAML file.
+Update an existing pipeline from a local YAML file.
 
 ```bash
 export ORCHESTRA_API_KEY=...
@@ -223,16 +223,19 @@ orchestra pipeline update \
 
 Options
 
-- `-a, --alias` (required): Pipeline alias to update.
+- `-a, --alias` (optional): Pipeline alias.
+- `-i, --pipeline-id` (optional): Pipeline ID.
 - `-p, --path` (required): Path to pipeline YAML file.
 - `--publish/--no-publish` (optional, default `--no-publish`): Whether the pipeline is published.
 
 Behavior
 
 - Validates YAML against the Orchestra schema endpoint before updating.
-- Sends pipeline data to `PUT /pipelines/{alias}` with `storage_provider=ORCHESTRA`.
-- Only Orchestra-backed pipelines can be updated via this endpoint (Git-backed pipelines are rejected).
-- On success, prints the pipeline edit URL (`/pipelines/{pipeline_id}/edit`) when an ID is returned.
+- Resolves the pipeline selector with shared rules (alias, then pipeline ID, then `repository + yaml_path` from `--path` inside git).
+- Fetches pipeline metadata from `GET /pipeline` before mutating.
+- If the pipeline is Orchestra-backed, updates it through `PUT /pipelines` using `alias` or `pipeline_id`.
+- If the pipeline is git-backed, applies the same commit/push protection flow as `pipeline build`, then reports the branch + commit used.
+- For Orchestra-backed success, prints the pipeline edit URL (`/pipelines/{pipeline_id}/edit`) when an ID is returned.
 - Exit codes: `0` on success, `1` on failure.
 
 ---
@@ -336,7 +339,7 @@ Behavior
 - When only `--path` is provided inside a git repository, the CLI looks up the existing pipeline using `repository` + `yaml_path`.
 - When the pipeline does not exist, the CLI creates a draft Orchestra-backed pipeline from the local YAML, generating an alias from `--path` via the shared selector helper when needed.
 - When the pipeline exists and is Orchestra-backed, the CLI updates that draft and starts the returned `versionNumber`, preserving the same wait, polling, and branch/commit override behavior as `pipeline run`.
-- Existing git-backed pipelines are detected during lookup and currently exit with a clear error rather than attempting an unsupported update flow.
+- Existing git-backed pipelines reuse the same commit + branch-protection logic as `pipeline update`, then run using the resolved branch/commit target.
 - Exit codes follow `pipeline run`: success terminal states return `0`; failed or cancelled runs return `1`.
 
 ---

--- a/orchestra_cli/src/README.md
+++ b/orchestra_cli/src/README.md
@@ -10,7 +10,7 @@ CLI command implementations. See `AGENTS.md` for conventions, patterns, and how 
 | `validate_pipeline.py` | `orchestra pipeline validate` — validates a YAML against the API schema |
 | `import_pipeline.py` | `orchestra pipeline import` — registers a pipeline from a git repo under an alias |
 | `create_pipeline.py` | `orchestra pipeline new` — creates an Orchestra-backed pipeline from a local YAML |
-| `update_pipeline.py` | `orchestra pipeline update` — updates an Orchestra-backed pipeline from a local YAML |
+| `update_pipeline.py` | `orchestra pipeline update` — updates a pipeline from local YAML (Orchestra-backed upsert or git-backed commit/push flow) |
 | `get_pipeline.py` | `orchestra pipeline get` — fetches one pipeline by selector |
 | `fetch_pipelines.py` | `orchestra pipeline list` — fetches pipelines visible to the current API key |
 | `delete_pipeline.py` | `orchestra pipeline delete` — deletes a pipeline by alias |

--- a/orchestra_cli/src/build_pipeline.py
+++ b/orchestra_cli/src/build_pipeline.py
@@ -6,7 +6,6 @@ import typer
 from ..utils.api import auth_headers, fail_with_response, request_or_exit, require_api_key
 from ..utils.constants import get_create_pipeline_url, get_pipeline_url, get_update_pipeline_url
 from ..utils.git import confirm_git_warnings_or_exit, prepare_git_backed_run_target
-from ..utils.pipeline_update import build_update_selector, storage_provider
 from ..utils.pipeline_selector import (
     PipelineSelector,
     pipeline_alias_option,
@@ -14,6 +13,7 @@ from ..utils.pipeline_selector import (
     pipeline_path_option,
     resolve_pipeline_selector,
 )
+from ..utils.pipeline_update import build_update_selector, storage_provider
 from ..utils.styling import green, red
 from ..utils.yaml_loader import load_validated_pipeline_data
 from .pipeline_upsert import (

--- a/orchestra_cli/src/build_pipeline.py
+++ b/orchestra_cli/src/build_pipeline.py
@@ -6,6 +6,7 @@ import typer
 from ..utils.api import auth_headers, fail_with_response, request_or_exit, require_api_key
 from ..utils.constants import get_create_pipeline_url, get_pipeline_url, get_update_pipeline_url
 from ..utils.git import confirm_git_warnings_or_exit, prepare_git_backed_run_target
+from ..utils.pipeline_update import build_update_selector, storage_provider
 from ..utils.pipeline_selector import (
     PipelineSelector,
     pipeline_alias_option,
@@ -64,21 +65,6 @@ def _lookup_existing_pipeline(
     return require_pipeline_body_from_success_response(response, "Build")
 
 
-def _build_update_selector(existing_pipeline: dict[str, object]) -> PipelineSelector:
-    pipeline_id = existing_pipeline.get("id") or existing_pipeline.get("pipeline_id")
-    if pipeline_id:
-        return PipelineSelector(pipeline_id=str(pipeline_id))
-
-    alias = existing_pipeline.get("alias")
-    if alias:
-        return PipelineSelector(alias=str(alias))
-
-    typer.echo(
-        red("❌ Build failed: existing pipeline metadata did not include alias or pipeline id"),
-    )
-    raise typer.Exit(code=1)
-
-
 def _build_create_selector(
     path: Path,
     lookup_selector: PipelineSelector,
@@ -94,14 +80,6 @@ def _build_create_selector(
         use_git_path_selector=False,
         force=force,
     )
-
-
-def _storage_provider(existing_pipeline: dict[str, object]) -> str | None:
-    for key in ("storage_provider", "storageProvider"):
-        value = existing_pipeline.get(key)
-        if isinstance(value, str):
-            return value
-    return None
 
 
 def _create_draft_pipeline(
@@ -141,7 +119,7 @@ def _update_draft_pipeline(
     pipeline_data: dict[str, object],
     api_key: str,
 ) -> tuple[PipelineSelector, int]:
-    update_selector = _build_update_selector(existing_pipeline)
+    update_selector = build_update_selector(existing_pipeline, "Build")
     payload = build_upsert_payload(pipeline_data, publish=False, selector=update_selector)
 
     typer.echo(f"Updating draft pipeline ({update_selector.display()})")
@@ -220,8 +198,8 @@ def build_pipeline(
         )
         return
 
-    storage_provider = _storage_provider(existing_pipeline)
-    if storage_provider is None or storage_provider == "ORCHESTRA":
+    pipeline_storage_provider = storage_provider(existing_pipeline)
+    if pipeline_storage_provider is None or pipeline_storage_provider == "ORCHESTRA":
         run_selector, version_number = _update_draft_pipeline(
             existing_pipeline=existing_pipeline,
             pipeline_data=pipeline_data,
@@ -242,7 +220,7 @@ def build_pipeline(
         )
         return
 
-    run_selector = _build_update_selector(existing_pipeline)
+    run_selector = build_update_selector(existing_pipeline, "Build")
     if branch or commit:
         typer.echo(
             red(

--- a/orchestra_cli/src/update_pipeline.py
+++ b/orchestra_cli/src/update_pipeline.py
@@ -9,20 +9,64 @@ from ..utils.api import (
     request_or_exit,
     require_api_key,
 )
-from ..utils.constants import get_update_pipeline_url
+from ..utils.constants import get_pipeline_url, get_update_pipeline_url
+from ..utils.git import prepare_git_backed_run_target
 from ..utils.pipeline_selector import (
+    PipelineSelector,
     pipeline_alias_option,
     pipeline_id_option,
     pipeline_path_option,
     resolve_pipeline_selector,
 )
-from ..utils.styling import red
+from ..utils.styling import green, red
 from ..utils.yaml_loader import load_validated_pipeline_data
 from .pipeline_upsert import (
     build_upsert_payload,
     emit_success_with_edit_url,
+    require_pipeline_body_from_success_response,
     require_pipeline_id_from_success_response,
 )
+
+
+def _lookup_existing_pipeline(
+    selector: PipelineSelector,
+    api_key: str,
+) -> dict[str, object]:
+    response = request_or_exit(
+        httpx.get,
+        get_pipeline_url(),
+        params=selector.to_payload(),
+        timeout=30,
+        headers=auth_headers(api_key),
+    )
+
+    if response.status_code != 200:
+        raise fail_with_response("Update", response)
+
+    return require_pipeline_body_from_success_response(response, "Update")
+
+
+def _build_update_selector(existing_pipeline: dict[str, object]) -> PipelineSelector:
+    pipeline_id = existing_pipeline.get("id") or existing_pipeline.get("pipeline_id")
+    if pipeline_id:
+        return PipelineSelector(pipeline_id=str(pipeline_id))
+
+    alias = existing_pipeline.get("alias")
+    if alias:
+        return PipelineSelector(alias=str(alias))
+
+    typer.echo(
+        red("❌ Update failed: existing pipeline metadata did not include alias or pipeline id"),
+    )
+    raise typer.Exit(code=1)
+
+
+def _storage_provider(existing_pipeline: dict[str, object]) -> str | None:
+    for key in ("storage_provider", "storageProvider"):
+        value = existing_pipeline.get(key)
+        if isinstance(value, str):
+            return value
+    return None
 
 
 def update_pipeline(
@@ -42,9 +86,28 @@ def update_pipeline(
     if path is None:
         typer.echo(red("Provide --path to update a pipeline from YAML"))
         raise typer.Exit(code=1)
-    selector = resolve_pipeline_selector(alias, pipeline_id, path, use_git_path_selector=False)
+    selector = resolve_pipeline_selector(alias, pipeline_id, path)
     data = load_validated_pipeline_data(path)
-    payload = build_upsert_payload(data, publish, selector)
+    existing_pipeline = _lookup_existing_pipeline(selector, api_key)
+    storage_provider = (_storage_provider(existing_pipeline) or "ORCHESTRA").upper()
+
+    if storage_provider != "ORCHESTRA":
+        update_selector = _build_update_selector(existing_pipeline)
+        git_branch, git_commit = prepare_git_backed_run_target(
+            path=path,
+            existing_pipeline=existing_pipeline,
+            force=False,
+        )
+        typer.echo(
+            green(
+                "✅ Updated git-backed pipeline "
+                f"({update_selector.display()}) on branch '{git_branch}' at commit {git_commit}",
+            ),
+        )
+        raise typer.Exit(code=0)
+
+    update_selector = _build_update_selector(existing_pipeline)
+    payload = build_upsert_payload(data, publish, update_selector)
 
     response = request_or_exit(
         httpx.put,
@@ -56,7 +119,7 @@ def update_pipeline(
 
     if response.status_code == 200:
         pipeline_id = require_pipeline_id_from_success_response(response, "Update")
-        emit_success_with_edit_url(selector.display(), "updated", pipeline_id)
+        emit_success_with_edit_url(update_selector.display(), "updated", pipeline_id)
         raise typer.Exit(code=0)
 
     raise fail_with_response("Update", response)

--- a/orchestra_cli/src/update_pipeline.py
+++ b/orchestra_cli/src/update_pipeline.py
@@ -80,6 +80,7 @@ def update_pipeline(
             path=path,
             existing_pipeline=existing_pipeline,
             force=force,
+            action="Update",
         )
         typer.echo(
             green(

--- a/orchestra_cli/src/update_pipeline.py
+++ b/orchestra_cli/src/update_pipeline.py
@@ -18,6 +18,7 @@ from ..utils.pipeline_selector import (
     pipeline_path_option,
     resolve_pipeline_selector,
 )
+from ..utils.pipeline_update import build_update_selector, storage_provider
 from ..utils.styling import green, red
 from ..utils.yaml_loader import load_validated_pipeline_data
 from .pipeline_upsert import (
@@ -46,29 +47,6 @@ def _lookup_existing_pipeline(
     return require_pipeline_body_from_success_response(response, "Update")
 
 
-def _build_update_selector(existing_pipeline: dict[str, object]) -> PipelineSelector:
-    pipeline_id = existing_pipeline.get("id") or existing_pipeline.get("pipeline_id")
-    if pipeline_id:
-        return PipelineSelector(pipeline_id=str(pipeline_id))
-
-    alias = existing_pipeline.get("alias")
-    if alias:
-        return PipelineSelector(alias=str(alias))
-
-    typer.echo(
-        red("❌ Update failed: existing pipeline metadata did not include alias or pipeline id"),
-    )
-    raise typer.Exit(code=1)
-
-
-def _storage_provider(existing_pipeline: dict[str, object]) -> str | None:
-    for key in ("storage_provider", "storageProvider"):
-        value = existing_pipeline.get(key)
-        if isinstance(value, str):
-            return value
-    return None
-
-
 def update_pipeline(
     path: Path | None = pipeline_path_option(),
     alias: str | None = pipeline_alias_option(),
@@ -78,6 +56,11 @@ def update_pipeline(
         "--publish/--no-publish",
         help="Whether the pipeline is published and can be triggered",
     ),
+    force: bool = typer.Option(
+        False,
+        "--force/--no-force",
+        help="Ignore prompts and continue with inferred git update choices",
+    ),
 ):
     """
     Update an Orchestra-backed pipeline from a local YAML file.
@@ -86,17 +69,17 @@ def update_pipeline(
     if path is None:
         typer.echo(red("Provide --path to update a pipeline from YAML"))
         raise typer.Exit(code=1)
-    selector = resolve_pipeline_selector(alias, pipeline_id, path)
+    selector = resolve_pipeline_selector(alias, pipeline_id, path, force=force)
     data = load_validated_pipeline_data(path)
     existing_pipeline = _lookup_existing_pipeline(selector, api_key)
-    storage_provider = (_storage_provider(existing_pipeline) or "ORCHESTRA").upper()
+    pipeline_storage_provider = (storage_provider(existing_pipeline) or "ORCHESTRA").upper()
 
-    if storage_provider != "ORCHESTRA":
-        update_selector = _build_update_selector(existing_pipeline)
+    if pipeline_storage_provider != "ORCHESTRA":
+        update_selector = build_update_selector(existing_pipeline, "Update")
         git_branch, git_commit = prepare_git_backed_run_target(
             path=path,
             existing_pipeline=existing_pipeline,
-            force=False,
+            force=force,
         )
         typer.echo(
             green(
@@ -106,7 +89,7 @@ def update_pipeline(
         )
         raise typer.Exit(code=0)
 
-    update_selector = _build_update_selector(existing_pipeline)
+    update_selector = build_update_selector(existing_pipeline, "Update")
     payload = build_upsert_payload(data, publish, update_selector)
 
     response = request_or_exit(

--- a/orchestra_cli/tests/test_update_pipeline.py
+++ b/orchestra_cli/tests/test_update_pipeline.py
@@ -241,7 +241,10 @@ def test_update_orchestra_backed_api_error(tmp_path: Path, httpx_mock: HTTPXMock
     assert "Only orchestra-backed pipelines can be updated via this endpoint." in result.output
 
 
-def test_update_fails_when_pipeline_lookup_returns_error_status(tmp_path: Path, httpx_mock: HTTPXMock):
+def test_update_fails_when_pipeline_lookup_returns_error_status(
+    tmp_path: Path,
+    httpx_mock: HTTPXMock,
+):
     yaml_file = tmp_path / "pipe.yaml"
     yaml_file.write_text("name: demo\nversion: 1\n")
 

--- a/orchestra_cli/tests/test_update_pipeline.py
+++ b/orchestra_cli/tests/test_update_pipeline.py
@@ -177,6 +177,65 @@ def test_update_path_inside_git_uses_repository_selector(
     assert "updated successfully" in result.output
 
 
+def test_update_path_only_outside_git_force_skips_alias_prompt(
+    httpx_mock: HTTPXMock,
+    monkeypatch,
+    tmp_path: Path,
+):
+    yaml_file = tmp_path / "My Pipeline.yaml"
+    yaml_file.write_text("name: demo\nversion: 1\n")
+
+    import subprocess
+
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        make_git_subprocess_mock(
+            {("rev-parse", "--show-toplevel"): (1, "", "fatal: not a git repo")},
+        ),
+    )
+
+    def fail_input() -> str:
+        raise AssertionError("input should not be called when --force is set")
+
+    monkeypatch.setattr("builtins.input", fail_input)
+
+    httpx_mock.add_response(
+        method="POST",
+        url="https://app.getorchestra.io/api/engine/public/pipelines/schema",
+        json={"ok": True},
+        status_code=200,
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url="https://app.getorchestra.io/api/engine/public/pipeline?alias=my-pipeline",
+        json={"id": "pipeline-id", "alias": "my-pipeline", "storage_provider": "ORCHESTRA"},
+        status_code=200,
+    )
+    httpx_mock.add_response(
+        method="PUT",
+        url="https://app.getorchestra.io/api/engine/public/pipelines",
+        json={"id": "pipeline-id"},
+        status_code=200,
+        match_json={
+            "pipeline_id": "pipeline-id",
+            "data": {"name": "demo", "version": 1},
+            "published": False,
+            "storage_provider": "ORCHESTRA",
+        },
+    )
+
+    result = runner.invoke(
+        app,
+        ["pipeline", "update", "--path", str(yaml_file), "--force"],
+    )
+
+    assert result.exit_code == 0
+    assert "Press Enter to accept" not in result.output
+    assert "Generated alias: my-pipeline" in result.output
+    assert "updated successfully" in result.output
+
+
 def test_update_missing_api_key(monkeypatch, tmp_path: Path):
     yaml_file = tmp_path / "pipe.yaml"
     yaml_file.write_text("name: demo\n")
@@ -395,6 +454,94 @@ def test_update_git_backed_push_failure_can_retry_on_new_branch(
         "Updated git-backed pipeline "
         f"(pipeline_id: pipeline-id) on branch '{suggested_branch}' at commit abc1234"
     ) in result.output
+
+
+def test_update_git_backed_force_auto_accepts_branch_retry(
+    httpx_mock: HTTPXMock,
+    monkeypatch,
+    tmp_path: Path,
+):
+    yaml_file = tmp_path / "pipe.yaml"
+    yaml_file.write_text("name: demo\nversion: 1\n")
+    suggested_branch = "orchestra-migrate-pipeline-FORCE1"
+    monkeypatch.setattr(
+        git_module,
+        "suggest_migration_branch_name",
+        lambda: suggested_branch,
+    )
+
+    def fail_input() -> str:
+        raise AssertionError("input should not be called when --force is set")
+
+    monkeypatch.setattr("builtins.input", fail_input)
+
+    class Result:
+        def __init__(self, returncode: int, stdout: str = "", stderr: str = ""):
+            self.returncode = returncode
+            self.stdout = stdout
+            self.stderr = stderr
+
+    current_branch = "main"
+    head_commit = "2222222"
+
+    def run_git(args, cwd=None, capture_output=False, text=False, check=False):  # noqa: ARG001
+        nonlocal current_branch
+        nonlocal head_commit
+        key = tuple(args[1:])
+        if key == ("rev-parse", "--show-toplevel"):
+            return Result(0, str(tmp_path), "")
+        if key == ("remote", "get-url", "origin"):
+            return Result(0, "git@github.com:org/repo.git", "")
+        if key == ("status", "--porcelain", "--", "pipe.yaml"):
+            return Result(0, " M pipe.yaml", "")
+        if key == ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"):
+            return Result(0, "origin/main", "")
+        if key == ("rev-list", "--left-right", "--count", "@{u}...HEAD"):
+            return Result(0, "0 0", "")
+        if key == ("rev-parse", "--abbrev-ref", "HEAD"):
+            return Result(0, current_branch, "")
+        if key == ("add", "--", "pipe.yaml"):
+            return Result(0, "", "")
+        if key == ("commit", "-m", "Migrating pipeline: 'demo'"):
+            head_commit = "def5678"
+            return Result(0, "[main def5678] commit", "")
+        if key == ("push",):
+            return Result(1, "", "remote: push blocked by branch protection")
+        if key == ("checkout", "-b", suggested_branch):
+            current_branch = suggested_branch
+            return Result(0, "", "")
+        if key == ("push", "-u", "origin", suggested_branch):
+            return Result(0, "", "")
+        if key == ("rev-parse", "HEAD"):
+            return Result(0, head_commit, "")
+
+        return Result(1, "", f"unhandled git command: {key}")
+
+    import subprocess
+
+    monkeypatch.setattr(subprocess, "run", run_git)
+
+    httpx_mock.add_response(
+        method="POST",
+        url="https://app.getorchestra.io/api/engine/public/pipelines/schema",
+        json={"ok": True},
+        status_code=200,
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url="https://app.getorchestra.io/api/engine/public/pipeline?repository=org%2Frepo&yaml_path=pipe.yaml",
+        json={"id": "pipeline-id", "alias": "demo", "storage_provider": "GITHUB"},
+        status_code=200,
+    )
+
+    result = runner.invoke(
+        app,
+        ["pipeline", "update", "--path", str(yaml_file), "--force"],
+    )
+
+    assert result.exit_code == 0
+    assert "Press Enter" not in result.output
+    assert suggested_branch in result.output
 
 
 def test_update_success_without_pipeline_id_fails(tmp_path: Path, httpx_mock: HTTPXMock):

--- a/orchestra_cli/tests/test_update_pipeline.py
+++ b/orchestra_cli/tests/test_update_pipeline.py
@@ -5,6 +5,7 @@ from pytest_httpx import HTTPXMock
 from typer.testing import CliRunner
 
 from orchestra_cli.src.cli import app
+from orchestra_cli.utils import git as git_module
 from tests.conftest import make_git_subprocess_mock
 
 runner = CliRunner()
@@ -27,12 +28,18 @@ def test_update_success_default_no_publish(tmp_path: Path, httpx_mock: HTTPXMock
         status_code=200,
     )
     httpx_mock.add_response(
+        method="GET",
+        url="https://app.getorchestra.io/api/engine/public/pipeline?alias=demo",
+        json={"id": "pipeline-id", "alias": "demo", "storage_provider": "ORCHESTRA"},
+        status_code=200,
+    )
+    httpx_mock.add_response(
         method="PUT",
         url="https://app.getorchestra.io/api/engine/public/pipelines",
         json={"id": "pipeline-id"},
         status_code=200,
         match_json={
-            "alias": "demo",
+            "pipeline_id": "pipeline-id",
             "data": {"name": "demo", "version": 1},
             "published": False,
             "storage_provider": "ORCHESTRA",
@@ -56,12 +63,18 @@ def test_update_publish_flag(tmp_path: Path, httpx_mock: HTTPXMock):
         status_code=200,
     )
     httpx_mock.add_response(
+        method="GET",
+        url="https://app.getorchestra.io/api/engine/public/pipeline?alias=demo",
+        json={"id": "pipeline-id", "alias": "demo", "storage_provider": "ORCHESTRA"},
+        status_code=200,
+    )
+    httpx_mock.add_response(
         method="PUT",
         url="https://app.getorchestra.io/api/engine/public/pipelines",
         json={"id": "pipeline-id"},
         status_code=200,
         match_json={
-            "alias": "demo",
+            "pipeline_id": "pipeline-id",
             "data": {"name": "demo", "version": 1},
             "published": True,
             "storage_provider": "ORCHESTRA",
@@ -88,6 +101,12 @@ def test_update_success_by_pipeline_id(tmp_path: Path, httpx_mock: HTTPXMock):
         status_code=200,
     )
     httpx_mock.add_response(
+        method="GET",
+        url="https://app.getorchestra.io/api/engine/public/pipeline?pipeline_id=pipeline-id",
+        json={"id": "pipeline-id", "storage_provider": "ORCHESTRA"},
+        status_code=200,
+    )
+    httpx_mock.add_response(
         method="PUT",
         url="https://app.getorchestra.io/api/engine/public/pipelines",
         json={"id": "pipeline-id"},
@@ -108,9 +127,14 @@ def test_update_success_by_pipeline_id(tmp_path: Path, httpx_mock: HTTPXMock):
     assert "updated successfully" in result.output
 
 
-def test_update_path_inside_git_generates_alias(monkeypatch, tmp_path: Path, httpx_mock: HTTPXMock):
+def test_update_path_inside_git_uses_repository_selector(
+    monkeypatch,
+    tmp_path: Path,
+    httpx_mock: HTTPXMock,
+):
     repo_root = tmp_path
-    yaml_file = repo_root / "My Pipeline.yaml"
+    yaml_file = repo_root / "pipelines" / "pipe.yaml"
+    yaml_file.parent.mkdir()
     yaml_file.write_text("name: demo\nversion: 1\n")
 
     httpx_mock.add_response(
@@ -120,12 +144,18 @@ def test_update_path_inside_git_generates_alias(monkeypatch, tmp_path: Path, htt
         status_code=200,
     )
     httpx_mock.add_response(
+        method="GET",
+        url="https://app.getorchestra.io/api/engine/public/pipeline?repository=org%2Frepo&yaml_path=pipelines%2Fpipe.yaml",
+        json={"id": "pipeline-id", "storage_provider": "ORCHESTRA"},
+        status_code=200,
+    )
+    httpx_mock.add_response(
         method="PUT",
         url="https://app.getorchestra.io/api/engine/public/pipelines",
         json={"id": "pipeline-id"},
         status_code=200,
         match_json={
-            "alias": "my-pipeline",
+            "pipeline_id": "pipeline-id",
             "data": {"name": "demo", "version": 1},
             "published": False,
             "storage_provider": "ORCHESTRA",
@@ -134,6 +164,7 @@ def test_update_path_inside_git_generates_alias(monkeypatch, tmp_path: Path, htt
 
     mapping = {
         ("rev-parse", "--show-toplevel"): (0, str(repo_root), ""),
+        ("remote", "get-url", "origin"): (0, "git@github.com:org/repo.git", ""),
     }
     import subprocess
 
@@ -142,7 +173,7 @@ def test_update_path_inside_git_generates_alias(monkeypatch, tmp_path: Path, htt
     result = runner.invoke(app, ["pipeline", "update", "--path", str(yaml_file)], input="\n")
 
     assert result.exit_code == 0
-    assert "Generated alias: my-pipeline" in result.output
+    assert "Generated alias" not in result.output
     assert "updated successfully" in result.output
 
 
@@ -181,7 +212,7 @@ def test_update_schema_validation_error(tmp_path: Path, httpx_mock: HTTPXMock):
     assert "Validation failed" in result.output
 
 
-def test_update_api_error_orchestra_backed_only(tmp_path: Path, httpx_mock: HTTPXMock):
+def test_update_orchestra_backed_api_error(tmp_path: Path, httpx_mock: HTTPXMock):
     yaml_file = tmp_path / "pipe.yaml"
     yaml_file.write_text("name: demo\nversion: 1\n")
 
@@ -189,6 +220,12 @@ def test_update_api_error_orchestra_backed_only(tmp_path: Path, httpx_mock: HTTP
         method="POST",
         url="https://app.getorchestra.io/api/engine/public/pipelines/schema",
         json={"ok": True},
+        status_code=200,
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url="https://app.getorchestra.io/api/engine/public/pipeline?alias=demo",
+        json={"id": "pipeline-id", "alias": "demo", "storage_provider": "ORCHESTRA"},
         status_code=200,
     )
     httpx_mock.add_response(
@@ -204,6 +241,159 @@ def test_update_api_error_orchestra_backed_only(tmp_path: Path, httpx_mock: HTTP
     assert "Only orchestra-backed pipelines can be updated via this endpoint." in result.output
 
 
+def test_update_fails_when_pipeline_lookup_returns_error_status(tmp_path: Path, httpx_mock: HTTPXMock):
+    yaml_file = tmp_path / "pipe.yaml"
+    yaml_file.write_text("name: demo\nversion: 1\n")
+
+    httpx_mock.add_response(
+        method="POST",
+        url="https://app.getorchestra.io/api/engine/public/pipelines/schema",
+        json={"ok": True},
+        status_code=200,
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url="https://app.getorchestra.io/api/engine/public/pipeline?alias=demo",
+        json={"detail": "upstream error"},
+        status_code=503,
+    )
+
+    result = runner.invoke(app, ["pipeline", "update", "--alias", "demo", "--path", str(yaml_file)])
+    assert result.exit_code == 1
+    assert "Update failed with status 503" in result.output
+
+
+def test_update_git_backed_uses_current_git_target_without_upsert(
+    httpx_mock: HTTPXMock,
+    monkeypatch,
+    tmp_path: Path,
+):
+    yaml_file = tmp_path / "pipe.yaml"
+    yaml_file.write_text("name: demo\nversion: 1\n")
+
+    mapping = {
+        ("rev-parse", "--show-toplevel"): (0, str(tmp_path), ""),
+        ("remote", "get-url", "origin"): (0, "git@github.com:org/repo.git", ""),
+        ("status", "--porcelain", "--", "pipe.yaml"): (0, "", ""),
+        ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"): (0, "origin/main", ""),
+        ("rev-list", "--left-right", "--count", "@{u}...HEAD"): (0, "0 0", ""),
+        ("rev-parse", "--abbrev-ref", "HEAD"): (0, "main", ""),
+        ("rev-parse", "HEAD"): (0, "abc123", ""),
+    }
+    import subprocess
+
+    monkeypatch.setattr(subprocess, "run", make_git_subprocess_mock(mapping))
+
+    httpx_mock.add_response(
+        method="POST",
+        url="https://app.getorchestra.io/api/engine/public/pipelines/schema",
+        json={"ok": True},
+        status_code=200,
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url="https://app.getorchestra.io/api/engine/public/pipeline?repository=org%2Frepo&yaml_path=pipe.yaml",
+        json={"id": "pipeline-id", "alias": "demo", "storage_provider": "GITHUB"},
+        status_code=200,
+    )
+
+    result = runner.invoke(app, ["pipeline", "update", "--path", str(yaml_file)])
+
+    assert result.exit_code == 0
+    assert (
+        "Updated git-backed pipeline (pipeline_id: pipeline-id) on branch 'main' at commit abc123"
+        in result.output
+    )
+
+
+def test_update_git_backed_push_failure_can_retry_on_new_branch(
+    httpx_mock: HTTPXMock,
+    monkeypatch,
+    tmp_path: Path,
+):
+    yaml_file = tmp_path / "pipe.yaml"
+    yaml_file.write_text("name: demo\nversion: 1\n")
+    suggested_branch = "orchestra-migrate-pipeline-ABC123"
+    monkeypatch.setattr(
+        git_module,
+        "suggest_migration_branch_name",
+        lambda: suggested_branch,
+    )
+
+    class Result:
+        def __init__(self, returncode: int, stdout: str = "", stderr: str = ""):
+            self.returncode = returncode
+            self.stdout = stdout
+            self.stderr = stderr
+
+    current_branch = "main"
+    head_commit = "1111111"
+
+    def run_git(args, cwd=None, capture_output=False, text=False, check=False):  # noqa: ARG001
+        nonlocal current_branch
+        nonlocal head_commit
+        key = tuple(args[1:])
+        if key == ("rev-parse", "--show-toplevel"):
+            return Result(0, str(tmp_path), "")
+        if key == ("remote", "get-url", "origin"):
+            return Result(0, "git@github.com:org/repo.git", "")
+        if key == ("status", "--porcelain", "--", "pipe.yaml"):
+            return Result(0, " M pipe.yaml", "")
+        if key == ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"):
+            return Result(0, "origin/main", "")
+        if key == ("rev-list", "--left-right", "--count", "@{u}...HEAD"):
+            return Result(0, "0 0", "")
+        if key == ("rev-parse", "--abbrev-ref", "HEAD"):
+            return Result(0, current_branch, "")
+        if key == ("add", "--", "pipe.yaml"):
+            return Result(0, "", "")
+        if key == ("commit", "-m", "Migrating pipeline: 'demo'"):
+            head_commit = "abc1234"
+            return Result(0, "[main abc1234] commit", "")
+        if key == ("push",):
+            return Result(1, "", "remote: push blocked by branch protection")
+        if key == ("checkout", "-b", suggested_branch):
+            current_branch = suggested_branch
+            return Result(0, "", "")
+        if key == ("push", "-u", "origin", suggested_branch):
+            return Result(0, "", "")
+        if key == ("rev-parse", "HEAD"):
+            return Result(0, head_commit, "")
+
+        return Result(1, "", f"unhandled git command: {key}")
+
+    import subprocess
+
+    monkeypatch.setattr(subprocess, "run", run_git)
+
+    httpx_mock.add_response(
+        method="POST",
+        url="https://app.getorchestra.io/api/engine/public/pipelines/schema",
+        json={"ok": True},
+        status_code=200,
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url="https://app.getorchestra.io/api/engine/public/pipeline?repository=org%2Frepo&yaml_path=pipe.yaml",
+        json={"id": "pipeline-id", "alias": "demo", "storage_provider": "GITHUB"},
+        status_code=200,
+    )
+
+    result = runner.invoke(
+        app,
+        ["pipeline", "update", "--path", str(yaml_file)],
+        input="\n\n\n\n",
+    )
+
+    assert result.exit_code == 0
+    assert "branch protection" in result.output
+    assert suggested_branch in result.output
+    assert (
+        "Updated git-backed pipeline "
+        f"(pipeline_id: pipeline-id) on branch '{suggested_branch}' at commit abc1234"
+    ) in result.output
+
+
 def test_update_success_without_pipeline_id_fails(tmp_path: Path, httpx_mock: HTTPXMock):
     yaml_file = tmp_path / "pipe.yaml"
     yaml_file.write_text("name: demo\nversion: 1\n")
@@ -212,6 +402,12 @@ def test_update_success_without_pipeline_id_fails(tmp_path: Path, httpx_mock: HT
         method="POST",
         url="https://app.getorchestra.io/api/engine/public/pipelines/schema",
         json={"ok": True},
+        status_code=200,
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url="https://app.getorchestra.io/api/engine/public/pipeline?alias=demo",
+        json={"id": "pipeline-id", "alias": "demo", "storage_provider": "ORCHESTRA"},
         status_code=200,
     )
     httpx_mock.add_response(
@@ -234,6 +430,12 @@ def test_update_success_with_invalid_json_fails(tmp_path: Path, httpx_mock: HTTP
         method="POST",
         url="https://app.getorchestra.io/api/engine/public/pipelines/schema",
         json={"ok": True},
+        status_code=200,
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url="https://app.getorchestra.io/api/engine/public/pipeline?alias=demo",
+        json={"id": "pipeline-id", "alias": "demo", "storage_provider": "ORCHESTRA"},
         status_code=200,
     )
     httpx_mock.add_response(

--- a/orchestra_cli/tests/test_update_pipeline.py
+++ b/orchestra_cli/tests/test_update_pipeline.py
@@ -368,6 +368,47 @@ def test_update_git_backed_uses_current_git_target_without_upsert(
     )
 
 
+def test_update_git_backed_reports_update_action_when_not_in_git_repo(
+    httpx_mock: HTTPXMock,
+    monkeypatch,
+    tmp_path: Path,
+):
+    yaml_file = tmp_path / "pipe.yaml"
+    yaml_file.write_text("name: demo\nversion: 1\n")
+
+    import subprocess
+
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        make_git_subprocess_mock(
+            {("rev-parse", "--show-toplevel"): (1, "", "fatal: not a git repo")},
+        ),
+    )
+
+    httpx_mock.add_response(
+        method="POST",
+        url="https://app.getorchestra.io/api/engine/public/pipelines/schema",
+        json={"ok": True},
+        status_code=200,
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url="https://app.getorchestra.io/api/engine/public/pipeline?alias=pipe",
+        json={"id": "pipeline-id", "alias": "pipe", "storage_provider": "GITHUB"},
+        status_code=200,
+    )
+
+    result = runner.invoke(
+        app,
+        ["pipeline", "update", "--path", str(yaml_file), "--force"],
+    )
+
+    assert result.exit_code == 1
+    assert "Update failed: YAML file must be inside a git repository" in result.output
+    assert "Build failed" not in result.output
+
+
 def test_update_git_backed_push_failure_can_retry_on_new_branch(
     httpx_mock: HTTPXMock,
     monkeypatch,

--- a/orchestra_cli/utils/git.py
+++ b/orchestra_cli/utils/git.py
@@ -101,40 +101,40 @@ def suggest_migration_branch_name() -> str:
     return f"orchestra-migrate-pipeline-{suffix}"
 
 
-def _require_repo_root(path: Path) -> Path:
+def _require_repo_root(path: Path, action: str) -> Path:
     repo_root = detect_repo_root(path.parent)
     if repo_root is not None:
         return repo_root
 
-    typer.echo(red("❌ Build failed: YAML file must be inside a git repository"))
+    typer.echo(red(f"❌ {action} failed: YAML file must be inside a git repository"))
     raise typer.Exit(code=1)
 
 
-def _require_repo_relative_path(path: Path, repo_root: Path) -> str:
+def _require_repo_relative_path(path: Path, repo_root: Path, action: str) -> str:
     try:
         return str(path.resolve().relative_to(repo_root.resolve()))
     except Exception:
-        typer.echo(red("❌ Build failed: YAML file must be inside the git repository"))
+        typer.echo(red(f"❌ {action} failed: YAML file must be inside the git repository"))
         raise typer.Exit(code=1)
 
 
-def _require_current_branch(repo_root: Path) -> str:
+def _require_current_branch(repo_root: Path, action: str) -> str:
     ok, branch = run_git_command(["rev-parse", "--abbrev-ref", "HEAD"], repo_root)
     if ok and branch:
         return branch
 
-    typer.echo(red("❌ Build failed: could not determine current git branch"))
+    typer.echo(red(f"❌ {action} failed: could not determine current git branch"))
     if branch:
         typer.echo(yellow(branch))
     raise typer.Exit(code=1)
 
 
-def _require_head_commit(repo_root: Path) -> str:
+def _require_head_commit(repo_root: Path, action: str) -> str:
     ok, head_commit = run_git_command(["rev-parse", "HEAD"], repo_root)
     if ok and head_commit:
         return head_commit
 
-    typer.echo(red("❌ Build failed: could not determine current git commit SHA"))
+    typer.echo(red(f"❌ {action} failed: could not determine current git commit SHA"))
     if head_commit:
         typer.echo(yellow(head_commit))
     raise typer.Exit(code=1)
@@ -196,12 +196,12 @@ def _pipeline_name_for_commit_message(existing_pipeline: dict[str, object], path
     return path.stem
 
 
-def _stage_selected_file(repo_root: Path, relative_path: str) -> None:
+def _stage_selected_file(repo_root: Path, relative_path: str, action: str) -> None:
     ok, output = run_git_command(["add", "--", relative_path], repo_root)
     if ok:
         return
 
-    typer.echo(red("❌ Build failed: could not stage selected YAML file"))
+    typer.echo(red(f"❌ {action} failed: could not stage selected YAML file"))
     if output:
         typer.echo(yellow(output))
     raise typer.Exit(code=1)
@@ -211,8 +211,8 @@ def _commit_selected_file(repo_root: Path, commit_message: str) -> tuple[bool, s
     return run_git_command(["commit", "-m", commit_message], repo_root)
 
 
-def _push_current_branch(repo_root: Path) -> tuple[bool, str]:
-    branch = _require_current_branch(repo_root)
+def _push_current_branch(repo_root: Path, action: str) -> tuple[bool, str]:
+    branch = _require_current_branch(repo_root, action)
     has_upstream, _ = run_git_command(
         ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
         repo_root,
@@ -234,8 +234,9 @@ def _recover_on_new_branch(
     commit_was_created: bool,
     failure_output: str,
     force: bool,
+    action: str,
 ) -> tuple[str, str]:
-    typer.echo(red("❌ Build failed while committing/pushing on the current branch."))
+    typer.echo(red(f"❌ {action} failed while committing/pushing on the current branch."))
     if failure_output:
         typer.echo(yellow(failure_output))
 
@@ -263,7 +264,7 @@ def _recover_on_new_branch(
         if should_cleanup:
             ok, reset_output = run_git_command(["reset", "--soft", "HEAD~1"], repo_root)
             if not ok:
-                typer.echo(red("❌ Build failed: could not clean up local commit"))
+                typer.echo(red(f"❌ {action} failed: could not clean up local commit"))
                 if reset_output:
                     typer.echo(yellow(reset_output))
                 raise typer.Exit(code=1)
@@ -274,45 +275,46 @@ def _recover_on_new_branch(
 
     ok, checkout_output = run_git_command(["checkout", "-b", target_branch], repo_root)
     if not ok:
-        typer.echo(red(f"❌ Build failed: could not create branch '{target_branch}'"))
+        typer.echo(red(f"❌ {action} failed: could not create branch '{target_branch}'"))
         if checkout_output:
             typer.echo(yellow(checkout_output))
         raise typer.Exit(code=1)
 
     if should_recommit_on_new_branch:
         if not commit_message:
-            typer.echo(red("❌ Build failed: missing commit message for retry commit"))
+            typer.echo(red(f"❌ {action} failed: missing commit message for retry commit"))
             raise typer.Exit(code=1)
-        _stage_selected_file(repo_root, relative_path)
+        _stage_selected_file(repo_root, relative_path, action)
         ok, commit_output = _commit_selected_file(repo_root, commit_message)
         if not ok:
-            typer.echo(red("❌ Build failed: could not commit changes on the new branch"))
+            typer.echo(red(f"❌ {action} failed: could not commit changes on the new branch"))
             if commit_output:
                 typer.echo(yellow(commit_output))
             raise typer.Exit(code=1)
 
     ok, push_output = _push_branch(repo_root, target_branch)
     if not ok:
-        typer.echo(red(f"❌ Build failed: couldn't push generated branch '{target_branch}'"))
+        typer.echo(red(f"❌ {action} failed: couldn't push generated branch '{target_branch}'"))
         if push_output:
             typer.echo(yellow(push_output))
         raise typer.Exit(code=1)
 
-    return target_branch, _require_head_commit(repo_root)
+    return target_branch, _require_head_commit(repo_root, action)
 
 
 def prepare_git_backed_run_target(
     path: Path,
     existing_pipeline: dict[str, object],
     force: bool,
+    action: str = "Build",
 ) -> tuple[str, str]:
-    repo_root = _require_repo_root(path)
-    relative_path = _require_repo_relative_path(path, repo_root)
+    repo_root = _require_repo_root(path, action)
+    relative_path = _require_repo_relative_path(path, repo_root, action)
     include_file_changes = _file_has_uncommitted_changes(repo_root, relative_path)
     has_unpushed_head = _head_is_unpushed(repo_root)
 
     if not include_file_changes and not has_unpushed_head:
-        return _require_current_branch(repo_root), _require_head_commit(repo_root)
+        return _require_current_branch(repo_root, action), _require_head_commit(repo_root, action)
 
     commit_message: str | None = None
     commit_was_created = False
@@ -323,7 +325,7 @@ def prepare_git_backed_run_target(
             f"Migrating pipeline: '{pipeline_name}'",
             force,
         )
-        _stage_selected_file(repo_root, relative_path)
+        _stage_selected_file(repo_root, relative_path, action)
         ok, commit_output = _commit_selected_file(repo_root, commit_message)
         if not ok:
             return _recover_on_new_branch(
@@ -334,10 +336,11 @@ def prepare_git_backed_run_target(
                 False,
                 commit_output,
                 force,
+                action,
             )
         commit_was_created = True
 
-    ok, push_output = _push_current_branch(repo_root)
+    ok, push_output = _push_current_branch(repo_root, action)
     if not ok:
         return _recover_on_new_branch(
             repo_root,
@@ -347,6 +350,7 @@ def prepare_git_backed_run_target(
             commit_was_created,
             push_output,
             force,
+            action,
         )
 
-    return _require_current_branch(repo_root), _require_head_commit(repo_root)
+    return _require_current_branch(repo_root, action), _require_head_commit(repo_root, action)

--- a/orchestra_cli/utils/pipeline_update.py
+++ b/orchestra_cli/utils/pipeline_update.py
@@ -1,0 +1,27 @@
+import typer
+
+from .pipeline_selector import PipelineSelector
+from .styling import red
+
+
+def build_update_selector(existing_pipeline: dict[str, object], action: str) -> PipelineSelector:
+    pipeline_id = existing_pipeline.get("id") or existing_pipeline.get("pipeline_id")
+    if pipeline_id:
+        return PipelineSelector(pipeline_id=str(pipeline_id))
+
+    alias = existing_pipeline.get("alias")
+    if alias:
+        return PipelineSelector(alias=str(alias))
+
+    typer.echo(
+        red(f"❌ {action} failed: existing pipeline metadata did not include alias or pipeline id"),
+    )
+    raise typer.Exit(code=1)
+
+
+def storage_provider(existing_pipeline: dict[str, object]) -> str | None:
+    for key in ("storage_provider", "storageProvider"):
+        value = existing_pipeline.get(key)
+        if isinstance(value, str):
+            return value
+    return None


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Objective
Align `pipeline update` with selector-based metadata lookup and git-backed update handling.

## Changes
- Resolve update targets with the shared selector rules and fetch pipeline metadata before update behavior decisions.
- Keep Orchestra-backed updates on the existing upsert endpoint while selecting alias/pipeline_id from fetched metadata.
- Add git-backed update behavior that reuses the same commit and branch-protection flow used by `pipeline build`.
- Add non-interactive `--force` support to `pipeline update` so git-backed commit/branch fallback prompts are safely bypassed in automation.
- Extract shared update-selector and storage-provider metadata helpers into `utils` to avoid duplicate command logic.
- Extend update tests to cover alias, pipeline ID, repository+yaml_path selectors, and force-mode prompt bypass behavior.
- Refresh CLI docs to describe the updated `pipeline update` behavior.

## Testing
Unit tested (`test_update_pipeline.py`, `test_build_pipeline.py`) and lint/type checks passed.

## Checklist
- [ ] Verified these changes are backwards compatible (db migrations, model updates)

## Additional Notes

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-9931](https://linear.app/getorchestra/issue/ENG-9931/align-pipeline-update-command)

<div><a href="https://cursor.com/agents/bc-b076b8fc-002c-4e03-8b69-459228894fb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b076b8fc-002c-4e03-8b69-459228894fb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

