### PR TITLE
[ENG-9793] Add pipeline migrate command

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ pipx install orchestra-cli
 
 ## Environment variables
 
-- `ORCHESTRA_API_KEY`: Required for actions that call the API (`pipeline import`, `pipeline new`, `pipeline update`, `pipeline get`, `pipeline list`, `pipeline delete`, `pipeline run`, `pipeline build`).
+- `ORCHESTRA_API_KEY`: Required for actions that call the API (`pipeline import`, `pipeline new`, `pipeline update`, `pipeline migrate`, `pipeline get`, `pipeline list`, `pipeline delete`, `pipeline run`, `pipeline build`).
 - `BASE_URL`: Optional. Override the default Orchestra host (`https://app.getorchestra.io`) for non‑production/testing.
 
 ## Command structure
@@ -35,6 +35,7 @@ Commands follow a `noun verb` shape. The current nouns are `pipeline` and `task`
 | `orchestra pipeline list`            | Fetch the pipelines visible to the current API key as JSON.                                 |
 | `orchestra pipeline new`             | Create an Orchestra-backed pipeline from a local YAML file.                                 |
 | `orchestra pipeline update`          | Update an existing Orchestra-backed pipeline from a local YAML file.                        |
+| `orchestra pipeline migrate`         | Migrate an Orchestra-backed pipeline to git-backed storage.                                 |
 | `orchestra pipeline delete`          | Delete an existing pipeline by alias.                                                       |
 | `orchestra pipeline run`             | Start a pipeline run by alias, optionally pinning branch/commit and waiting for completion. |
 | `orchestra pipeline build`           | Validate local YAML, create or update a draft pipeline, and start that draft version.       |
@@ -238,6 +239,38 @@ Behavior
 - If the pipeline is git-backed, applies the same commit/push protection flow as `pipeline build`, then reports the branch + commit used.
 - For Orchestra-backed success, prints the pipeline edit URL (`/pipelines/{pipeline_id}/edit`) when an ID is returned.
 - Exit codes: `0` on success, `1` on failure.
+
+---
+
+## pipeline migrate
+
+Migrate an existing Orchestra-backed pipeline to git-backed storage.
+
+```bash
+export ORCHESTRA_API_KEY=...
+
+orchestra pipeline migrate \
+  --alias my-pipeline \
+  --path ./pipelines/pipeline.yaml
+```
+
+Options
+
+- `-p, --path` (required): Target YAML path inside your git repository.
+- `-a, --alias` (optional): Pipeline alias selector.
+- `-i, --pipeline-id` (optional): Pipeline ID selector.
+- `--default-branch` (optional): Defaults to your git remote default branch.
+- `--working-branch` (optional): Defaults to your current git branch (unless it matches default branch).
+
+Behavior
+
+- Requires a git repository and a resolvable `origin` remote.
+- Fetches the selected pipeline, verifies it is Orchestra-backed, then downloads pipeline YAML from Orchestra.
+- If published and latest versions differ, prompts which version to migrate.
+- If a local file already exists at `--path` and differs, prompts to overwrite, keep local, or choose a new path.
+- Commits and pushes the selected YAML path before calling `PATCH /pipelines/storage-settings`.
+- If push is blocked by branch protection, suggests a new migration branch and offers to retry there.
+- Prints a compare/PR link when migration is pushed to a non-default branch.
 
 ---
 

--- a/orchestra_cli/src/README.md
+++ b/orchestra_cli/src/README.md
@@ -14,6 +14,8 @@ CLI command implementations. See `AGENTS.md` for conventions, patterns, and how 
 | `get_pipeline.py` | `orchestra pipeline get` — fetches one pipeline by selector |
 | `fetch_pipelines.py` | `orchestra pipeline list` — fetches pipelines visible to the current API key |
 | `delete_pipeline.py` | `orchestra pipeline delete` — deletes a pipeline by alias |
+| `build_pipeline.py` | `orchestra pipeline build` — validates local YAML, creates/updates a draft pipeline, and starts that draft version |
+| `migrate_pipeline.py` | `orchestra pipeline migrate` — migrates an Orchestra-backed pipeline to git-backed storage |
 | `run_pipeline.py` | `orchestra pipeline run` — starts a pipeline run; optionally polls until completion |
 
 Each command module exports a single public function registered in `cli.py`.

--- a/orchestra_cli/src/cli.py
+++ b/orchestra_cli/src/cli.py
@@ -6,6 +6,7 @@ from .delete_pipeline import delete_pipeline
 from .fetch_pipelines import fetch_pipelines
 from .get_pipeline import get_pipeline
 from .import_pipeline import import_pipeline
+from .migrate_pipeline import migrate_pipeline
 from .run_pipeline import run_pipeline
 from .task_logs import task_logs
 from .update_pipeline import update_pipeline
@@ -27,6 +28,7 @@ pipeline_app.command(name="list")(fetch_pipelines)
 pipeline_app.command(name="run")(run_pipeline)
 pipeline_app.command(name="build")(build_pipeline)
 pipeline_app.command(name="delete")(delete_pipeline)
+pipeline_app.command(name="migrate")(migrate_pipeline)
 task_app.command(name="logs")(task_logs)
 
 # Legacy top-level aliases (hidden) - keep the old `orchestra <command>` syntax working

--- a/orchestra_cli/src/import_pipeline.py
+++ b/orchestra_cli/src/import_pipeline.py
@@ -1,5 +1,4 @@
 import json
-import re
 from pathlib import Path
 
 import httpx
@@ -12,55 +11,18 @@ from ..utils.api import (
     require_api_key,
 )
 from ..utils.constants import get_api_url
-from ..utils.git import detect_repo_root, detect_repository_slug, git_warnings, run_git_command
+from ..utils.git import (
+    detect_current_branch,
+    detect_default_branch,
+    detect_repo_root,
+    detect_repository_slug,
+    detect_storage_provider,
+    get_remote_url,
+    git_warnings,
+)
 from ..utils.pipeline_selector import pipeline_alias_option, pipeline_path_option
 from ..utils.styling import bold, green, red, yellow
 from ..utils.yaml_loader import load_validated_pipeline_data
-
-
-def _get_remote_url(repo_root: Path) -> str | None:
-    """Return the raw git remote URL for origin without transformation."""
-    ok, remote = run_git_command(["remote", "get-url", "origin"], repo_root)
-    if not ok:
-        return None
-    return remote
-
-
-def _detect_default_branch(repo_root: Path) -> str | None:
-    # Try symbolic-ref of remote HEAD first
-    ok, out = run_git_command(["symbolic-ref", "refs/remotes/origin/HEAD"], repo_root)
-    if ok and out:
-        # refs/remotes/origin/main -> main
-        return out.split("/")[-1]
-    # Fallback to parsing `git remote show origin`
-    ok, out = run_git_command(["remote", "show", "origin"], repo_root)
-    if ok and out:
-        m = re.search(r"HEAD branch:\s*(\S+)", out)
-        if m:
-            return m.group(1)
-    return None
-
-
-def _detect_current_branch(repo_root: Path) -> str | None:
-    ok, out = run_git_command(["rev-parse", "--abbrev-ref", "HEAD"], repo_root)
-    if ok and out:
-        return out
-    return None
-
-
-def _detect_storage_provider(repository_url: str | None) -> str:
-    if not repository_url:
-        typer.echo(red("Could not detect storage provider - no repository URL"))
-        raise typer.Exit(code=1)
-    url = repository_url.lower()
-    if "github.com" in url:
-        return "GITHUB"
-    if "gitlab.com" in url:
-        return "GITLAB"
-    if any(host in url for host in ["dev.azure.com", "azure.com", "visualstudio.com"]):
-        return "AZURE_DEVOPS"
-    typer.echo(red("Could not detect storage provider - no matching host"))
-    raise typer.Exit(code=1)
 
 
 def import_pipeline(
@@ -98,14 +60,14 @@ def import_pipeline(
         typer.echo(red("Could not detect repository URL from git"))
         raise typer.Exit(code=1)
     if not default_branch:
-        default_branch = _detect_default_branch(repo_root)
+        default_branch = detect_default_branch(repo_root)
         if not default_branch:
             typer.echo(red("Could not detect default branch from git"))
             raise typer.Exit(code=1)
 
     # Determine working branch (explicit option or current branch)
     if working_branch is None:
-        working_branch = _detect_current_branch(repo_root)
+        working_branch = detect_current_branch(repo_root, allow_detached=False)
         if not working_branch:
             typer.echo(red("Could not detect current branch from git"))
             raise typer.Exit(code=1)
@@ -120,8 +82,13 @@ def import_pipeline(
     for w in git_warnings(repo_root):
         typer.echo(yellow(f"⚠ {w}"))
 
+    storage_provider = detect_storage_provider(get_remote_url(repo_root))
+    if not storage_provider:
+        typer.echo(red("Could not detect storage provider - no matching host"))
+        raise typer.Exit(code=1)
+
     payload = {
-        "storage_provider": _detect_storage_provider(_get_remote_url(repo_root)),
+        "storage_provider": storage_provider,
         "repository": repository_slug,
         "default_branch": default_branch,
         "working_branch": working_branch,

--- a/orchestra_cli/src/migrate_pipeline.py
+++ b/orchestra_cli/src/migrate_pipeline.py
@@ -381,7 +381,9 @@ def migrate_pipeline(
     existing_pipeline = _lookup_pipeline(selector, api_key)
     provider = (storage_provider(existing_pipeline) or "ORCHESTRA").upper()
     if provider != "ORCHESTRA":
-        typer.echo(red("Pipeline is already git-backed; only Orchestra-backed pipelines can be migrated"))
+        typer.echo(
+            red("Pipeline is already git-backed; only Orchestra-backed pipelines can be migrated"),
+        )
         raise typer.Exit(code=1)
 
     target_version = _choose_migration_version(existing_pipeline)

--- a/orchestra_cli/src/migrate_pipeline.py
+++ b/orchestra_cli/src/migrate_pipeline.py
@@ -18,6 +18,7 @@ from ..utils.git import (
     get_remote_url,
     is_branch_protection_error,
     run_git_command,
+    stage_and_commit_file_if_needed,
     suggest_migration_branch_name,
 )
 from ..utils.pipeline_selector import PipelineSelector, pipeline_alias_option, pipeline_id_option
@@ -242,43 +243,6 @@ def _write_yaml(path: Path, yaml_content: str) -> None:
     path.write_text(yaml_content)
 
 
-def _stage_and_commit_if_needed(
-    repo_root: Path,
-    relative_path: str,
-    selector: PipelineSelector,
-) -> None:
-    ok, status_output = run_git_command(["status", "--porcelain", "--", relative_path], repo_root)
-    if not ok:
-        typer.echo(red("❌ Migrate failed: could not inspect git status"))
-        if status_output:
-            typer.echo(yellow(status_output))
-        raise typer.Exit(code=1)
-
-    if not status_output:
-        return
-
-    ok, add_output = run_git_command(["add", "--", relative_path], repo_root)
-    if not ok:
-        typer.echo(red("❌ Migrate failed: could not stage YAML file"))
-        if add_output:
-            typer.echo(yellow(add_output))
-        raise typer.Exit(code=1)
-
-    pipeline_name = selector.alias or selector.pipeline_id or Path(relative_path).stem
-    commit_message = f"Migrate pipeline '{pipeline_name}' to git-backed storage"
-    ok, commit_output = run_git_command(["commit", "-m", commit_message], repo_root)
-    if ok:
-        return
-
-    if "nothing to commit" in commit_output.lower():
-        return
-
-    typer.echo(red("❌ Migrate failed: could not commit YAML file"))
-    if commit_output:
-        typer.echo(yellow(commit_output))
-    raise typer.Exit(code=1)
-
-
 def _prompt_branch_recovery(suggested_branch: str) -> bool:
     typer.echo(yellow(f"Suggested branch for retry: {suggested_branch}"))
     typer.echo(bold(yellow("Create and push this branch now? [Y/n]")))
@@ -392,7 +356,13 @@ def migrate_pipeline(
     _write_yaml(target_path, selected_yaml)
 
     relative_path = ensure_repo_relative_path(target_path, repo_root, "Migrate")
-    _stage_and_commit_if_needed(repo_root, relative_path, selector)
+    pipeline_name = selector.alias or selector.pipeline_id or Path(relative_path).stem
+    stage_and_commit_file_if_needed(
+        repo_root,
+        relative_path,
+        f"Migrate pipeline '{pipeline_name}' to git-backed storage",
+        "Migrate",
+    )
     pushed_branch = _push_migration_branch(repo_root, current_branch)
 
     storage_provider_value = detect_storage_provider(get_remote_url(repo_root))

--- a/orchestra_cli/src/migrate_pipeline.py
+++ b/orchestra_cli/src/migrate_pipeline.py
@@ -11,12 +11,13 @@ from ..utils.git import (
     build_compare_link,
     detect_current_branch,
     detect_default_branch,
-    detect_repo_root,
     detect_repository_slug,
     detect_storage_provider,
     ensure_repo_relative_path,
     get_remote_url,
     is_branch_protection_error,
+    push_branch,
+    require_repo_root,
     run_git_command,
     stage_and_commit_file_if_needed,
     suggest_migration_branch_name,
@@ -80,7 +81,7 @@ def _extract_version(existing_pipeline: dict[str, object], keys: tuple[str, ...]
     return None
 
 
-def _choose_migration_version(existing_pipeline: dict[str, object]) -> int | None:
+def _choose_migration_version(existing_pipeline: dict[str, object], force: bool) -> int | None:
     published_version = _extract_version(
         existing_pipeline,
         ("publishedVersionNumber", "published_version_number", "published_version", "published"),
@@ -98,6 +99,15 @@ def _choose_migration_version(existing_pipeline: dict[str, object]) -> int | Non
         return published_version
     if latest_version <= published_version:
         return published_version
+
+    if force:
+        typer.echo(
+            yellow(
+                "Detected published and newer latest pipeline versions; "
+                "--force selected latest version for migration.",
+            ),
+        )
+        return latest_version
 
     typer.echo(
         yellow(
@@ -171,7 +181,16 @@ def _format_yaml_diff(path: Path, local_yaml: str, remote_yaml: str) -> str:
     return "\n".join(diff_lines)
 
 
-def _prompt_conflict_resolution() -> str:
+def _prompt_conflict_resolution(force: bool) -> str:
+    if force:
+        typer.echo(
+            yellow(
+                "Local file differs from Orchestra YAML and --force is set; "
+                "keeping the local file.",
+            ),
+        )
+        return "local"
+
     typer.echo("  1) Overwrite local file with the Orchestra YAML")
     typer.echo("  2) Keep and use the local file")
     typer.echo("  3) Provide a different filepath")
@@ -211,7 +230,7 @@ def _prompt_new_path() -> Path:
     return candidate.resolve()
 
 
-def _resolve_target_path_and_yaml(path: Path, remote_yaml: str) -> tuple[Path, str]:
+def _resolve_target_path_and_yaml(path: Path, remote_yaml: str, force: bool) -> tuple[Path, str]:
     selected_path = path
     selected_yaml = remote_yaml
 
@@ -226,7 +245,7 @@ def _resolve_target_path_and_yaml(path: Path, remote_yaml: str) -> tuple[Path, s
         if diff_output:
             typer.echo(diff_output)
 
-        resolution = _prompt_conflict_resolution()
+        resolution = _prompt_conflict_resolution(force)
         if resolution == "overwrite":
             return selected_path, remote_yaml
         if resolution == "local":
@@ -243,7 +262,11 @@ def _write_yaml(path: Path, yaml_content: str) -> None:
     path.write_text(yaml_content)
 
 
-def _prompt_branch_recovery(suggested_branch: str) -> bool:
+def _prompt_branch_recovery(suggested_branch: str, force: bool) -> bool:
+    if force:
+        typer.echo(yellow(f"--force set; retrying push on suggested branch: {suggested_branch}"))
+        return True
+
     typer.echo(yellow(f"Suggested branch for retry: {suggested_branch}"))
     typer.echo(bold(yellow("Create and push this branch now? [Y/n]")))
     try:
@@ -254,17 +277,8 @@ def _prompt_branch_recovery(suggested_branch: str) -> bool:
     return response in ("", "y", "yes")
 
 
-def _push_branch(repo_root: Path, branch_name: str) -> tuple[bool, str]:
-    has_upstream, _ = run_git_command(
-        ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
-        repo_root,
-    )
-    push_args = ["push"] if has_upstream else ["push", "-u", "origin", branch_name]
-    return run_git_command(push_args, repo_root)
-
-
-def _push_migration_branch(repo_root: Path, branch_name: str) -> str:
-    ok, push_output = _push_branch(repo_root, branch_name)
+def _push_migration_branch(repo_root: Path, branch_name: str, force: bool) -> str:
+    ok, push_output = push_branch(repo_root, branch_name)
     if ok:
         return branch_name
 
@@ -279,7 +293,7 @@ def _push_migration_branch(repo_root: Path, branch_name: str) -> str:
         typer.echo(yellow(push_output))
 
     suggested_branch = suggest_migration_branch_name()
-    if not _prompt_branch_recovery(suggested_branch):
+    if not _prompt_branch_recovery(suggested_branch, force):
         typer.echo(red("Aborted migration because the YAML was not pushed to git"))
         raise typer.Exit(code=1)
 
@@ -290,7 +304,7 @@ def _push_migration_branch(repo_root: Path, branch_name: str) -> str:
             typer.echo(yellow(checkout_output))
         raise typer.Exit(code=1)
 
-    ok, retry_push_output = run_git_command(["push", "-u", "origin", suggested_branch], repo_root)
+    ok, retry_push_output = push_branch(repo_root, suggested_branch)
     if not ok:
         typer.echo(red(f"❌ Migrate failed: could not push branch '{suggested_branch}'"))
         if retry_push_output:
@@ -314,6 +328,11 @@ def migrate_pipeline(
         "--default-branch",
         help="Default branch to store in Orchestra (defaults to git remote default branch)",
     ),
+    force: bool = typer.Option(
+        False,
+        "--force/--no-force",
+        help="Skip interactive prompts and continue with inferred migration choices",
+    ),
 ) -> None:
     """
     Migrate an Orchestra-backed pipeline to git-backed storage.
@@ -321,10 +340,7 @@ def migrate_pipeline(
     api_key = require_api_key()
     selector = _resolve_migrate_selector(alias, pipeline_id)
 
-    repo_root = detect_repo_root(path.parent)
-    if repo_root is None:
-        typer.echo(red("Not a git repository (could not detect repository root)"))
-        raise typer.Exit(code=1)
+    repo_root = require_repo_root(path, "Migrate")
 
     repository_slug = detect_repository_slug(repo_root)
     if not repository_slug:
@@ -350,9 +366,9 @@ def migrate_pipeline(
         )
         raise typer.Exit(code=1)
 
-    target_version = _choose_migration_version(existing_pipeline)
+    target_version = _choose_migration_version(existing_pipeline, force)
     downloaded_yaml = _download_pipeline_yaml(selector, target_version, api_key)
-    target_path, selected_yaml = _resolve_target_path_and_yaml(path, downloaded_yaml)
+    target_path, selected_yaml = _resolve_target_path_and_yaml(path, downloaded_yaml, force)
     _write_yaml(target_path, selected_yaml)
 
     relative_path = ensure_repo_relative_path(target_path, repo_root, "Migrate")
@@ -363,7 +379,7 @@ def migrate_pipeline(
         f"Migrate pipeline '{pipeline_name}' to git-backed storage",
         "Migrate",
     )
-    pushed_branch = _push_migration_branch(repo_root, current_branch)
+    pushed_branch = _push_migration_branch(repo_root, current_branch, force)
 
     storage_provider_value = detect_storage_provider(get_remote_url(repo_root))
     if not storage_provider_value:

--- a/orchestra_cli/src/migrate_pipeline.py
+++ b/orchestra_cli/src/migrate_pipeline.py
@@ -8,6 +8,7 @@ import typer
 from ..utils.api import auth_headers, fail_with_response, request_or_exit, require_api_key
 from ..utils.constants import get_api_url
 from ..utils.git import (
+    GitAction,
     build_compare_link,
     detect_current_branch,
     detect_default_branch,
@@ -340,11 +341,16 @@ def migrate_pipeline(
     api_key = require_api_key()
     selector = _resolve_migrate_selector(alias, pipeline_id)
 
-    repo_root = require_repo_root(path, "Migrate")
+    repo_root = require_repo_root(path, GitAction.MIGRATE)
 
     repository_slug = detect_repository_slug(repo_root)
     if not repository_slug:
         typer.echo(red("Could not detect repository URL from git"))
+        raise typer.Exit(code=1)
+
+    storage_provider_value = detect_storage_provider(get_remote_url(repo_root))
+    if not storage_provider_value:
+        typer.echo(red("Could not detect storage provider - no matching host"))
         raise typer.Exit(code=1)
 
     if not default_branch:
@@ -371,20 +377,15 @@ def migrate_pipeline(
     target_path, selected_yaml = _resolve_target_path_and_yaml(path, downloaded_yaml, force)
     _write_yaml(target_path, selected_yaml)
 
-    relative_path = ensure_repo_relative_path(target_path, repo_root, "Migrate")
+    relative_path = ensure_repo_relative_path(target_path, repo_root, GitAction.MIGRATE)
     pipeline_name = selector.alias or selector.pipeline_id or Path(relative_path).stem
     stage_and_commit_file_if_needed(
         repo_root,
         relative_path,
         f"Migrate pipeline '{pipeline_name}' to git-backed storage",
-        "Migrate",
+        GitAction.MIGRATE,
     )
     pushed_branch = _push_migration_branch(repo_root, current_branch, force)
-
-    storage_provider_value = detect_storage_provider(get_remote_url(repo_root))
-    if not storage_provider_value:
-        typer.echo(red("Could not detect storage provider - no matching host"))
-        raise typer.Exit(code=1)
 
     effective_working_branch = working_branch or pushed_branch
     payload: dict[str, str] = {

--- a/orchestra_cli/src/migrate_pipeline.py
+++ b/orchestra_cli/src/migrate_pipeline.py
@@ -1,0 +1,445 @@
+import difflib
+from pathlib import Path
+from typing import Any
+
+import httpx
+import typer
+
+from ..utils.api import auth_headers, fail_with_response, request_or_exit, require_api_key
+from ..utils.constants import get_api_url
+from ..utils.git import (
+    build_compare_link,
+    detect_current_branch,
+    detect_default_branch,
+    detect_repo_root,
+    detect_repository_slug,
+    detect_storage_provider,
+    ensure_repo_relative_path,
+    get_remote_url,
+    is_branch_protection_error,
+    run_git_command,
+    suggest_migration_branch_name,
+)
+from ..utils.pipeline_selector import PipelineSelector, pipeline_alias_option, pipeline_id_option
+from ..utils.pipeline_update import storage_provider
+from ..utils.styling import bold, green, red, yellow
+from .pipeline_upsert import require_pipeline_body_from_success_response
+
+
+def migrate_path_option() -> Any:
+    return typer.Option(
+        ...,
+        "--path",
+        "-p",
+        file_okay=True,
+        dir_okay=False,
+        resolve_path=True,
+        help="Path where the migrated pipeline YAML should live in the repository",
+    )
+
+
+def _resolve_migrate_selector(alias: str | None, pipeline_id: str | None) -> PipelineSelector:
+    if alias:
+        return PipelineSelector(alias=alias)
+    if pipeline_id:
+        return PipelineSelector(pipeline_id=pipeline_id)
+
+    typer.echo(red("Provide one of --alias or --pipeline-id"))
+    raise typer.Exit(code=1)
+
+
+def _lookup_pipeline(selector: PipelineSelector, api_key: str) -> dict[str, object]:
+    response = request_or_exit(
+        httpx.get,
+        get_api_url("pipeline"),
+        params=selector.to_payload(),
+        timeout=30,
+        headers=auth_headers(api_key),
+    )
+    if response.status_code != 200:
+        raise fail_with_response("Migrate", response)
+    return require_pipeline_body_from_success_response(response, "Migrate")
+
+
+def _extract_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.strip().isdigit():
+        return int(value.strip())
+    return None
+
+
+def _extract_version(existing_pipeline: dict[str, object], keys: tuple[str, ...]) -> int | None:
+    for key in keys:
+        version = _extract_int(existing_pipeline.get(key))
+        if version is not None:
+            return version
+    return None
+
+
+def _choose_migration_version(existing_pipeline: dict[str, object]) -> int | None:
+    published_version = _extract_version(
+        existing_pipeline,
+        ("publishedVersionNumber", "published_version_number", "published_version", "published"),
+    )
+    latest_version = _extract_version(
+        existing_pipeline,
+        ("latestVersionNumber", "latest_version_number", "latest_version", "latest"),
+    )
+
+    if published_version is None and latest_version is None:
+        return None
+    if published_version is None:
+        return latest_version
+    if latest_version is None:
+        return published_version
+    if latest_version <= published_version:
+        return published_version
+
+    typer.echo(
+        yellow(
+            "Pipeline has both a published and a newer latest version. "
+            "Choose which version to migrate (the other will be discarded).",
+        ),
+    )
+    typer.echo(f"  1) Published version ({published_version})")
+    typer.echo(f"  2) Latest version ({latest_version})")
+    typer.echo(bold(yellow("Select 1 or 2, then press Enter (default: 2)")))
+    try:
+        choice = input().strip().lower()
+    except KeyboardInterrupt:
+        typer.echo(red("Aborted"))
+        raise typer.Exit(code=1)
+
+    if choice in ("", "2", "latest", "l"):
+        return latest_version
+    if choice in ("1", "published", "p"):
+        return published_version
+
+    typer.echo(red("Invalid selection. Enter 1 for published or 2 for latest."))
+    raise typer.Exit(code=1)
+
+
+def _download_pipeline_yaml(selector: PipelineSelector, version: int | None, api_key: str) -> str:
+    params = selector.to_payload()
+    if version is not None:
+        params["version"] = str(version)
+
+    response = request_or_exit(
+        httpx.get,
+        get_api_url("pipeline/data"),
+        params=params,
+        timeout=30,
+        headers=auth_headers(api_key),
+    )
+    if response.status_code != 200:
+        raise fail_with_response("Migrate", response)
+
+    try:
+        body = response.json()
+    except Exception:
+        return response.text
+
+    if isinstance(body, str):
+        return body
+    if isinstance(body, dict):
+        for key in ("yaml", "data", "content"):
+            value = body.get(key)
+            if isinstance(value, str):
+                return value
+
+    return response.text
+
+
+def _yaml_contents_match(local_yaml: str, remote_yaml: str) -> bool:
+    return local_yaml.strip() == remote_yaml.strip()
+
+
+def _format_yaml_diff(path: Path, local_yaml: str, remote_yaml: str) -> str:
+    diff_lines = list(
+        difflib.unified_diff(
+            local_yaml.splitlines(),
+            remote_yaml.splitlines(),
+            fromfile=f"{path} (local)",
+            tofile="Orchestra (remote)",
+            lineterm="",
+        ),
+    )
+    return "\n".join(diff_lines)
+
+
+def _prompt_conflict_resolution() -> str:
+    typer.echo("  1) Overwrite local file with the Orchestra YAML")
+    typer.echo("  2) Keep and use the local file")
+    typer.echo("  3) Provide a different filepath")
+    typer.echo(bold(yellow("Select 1, 2, or 3, then press Enter")))
+    try:
+        choice = input().strip().lower()
+    except KeyboardInterrupt:
+        typer.echo(red("Aborted"))
+        raise typer.Exit(code=1)
+
+    if choice in ("1", "overwrite", "o"):
+        return "overwrite"
+    if choice in ("2", "local", "l"):
+        return "local"
+    if choice in ("3", "path", "p"):
+        return "path"
+
+    typer.echo(red("Invalid selection. Enter 1, 2, or 3."))
+    raise typer.Exit(code=1)
+
+
+def _prompt_new_path() -> Path:
+    typer.echo(bold(yellow("Enter a new filepath for the YAML (relative paths are allowed):")))
+    try:
+        entered = input().strip()
+    except KeyboardInterrupt:
+        typer.echo(red("Aborted"))
+        raise typer.Exit(code=1)
+
+    if not entered:
+        typer.echo(red("Path cannot be empty"))
+        raise typer.Exit(code=1)
+
+    candidate = Path(entered).expanduser()
+    if not candidate.is_absolute():
+        candidate = Path.cwd() / candidate
+    return candidate.resolve()
+
+
+def _resolve_target_path_and_yaml(path: Path, remote_yaml: str) -> tuple[Path, str]:
+    selected_path = path
+    selected_yaml = remote_yaml
+
+    while selected_path.exists():
+        local_yaml = selected_path.read_text()
+        if _yaml_contents_match(local_yaml, remote_yaml):
+            typer.echo(yellow(f"Local file already matches Orchestra YAML: {selected_path}"))
+            return selected_path, local_yaml
+
+        typer.echo(yellow(f"Local file differs from Orchestra YAML: {selected_path}"))
+        diff_output = _format_yaml_diff(selected_path, local_yaml, remote_yaml)
+        if diff_output:
+            typer.echo(diff_output)
+
+        resolution = _prompt_conflict_resolution()
+        if resolution == "overwrite":
+            return selected_path, remote_yaml
+        if resolution == "local":
+            return selected_path, local_yaml
+
+        selected_path = _prompt_new_path()
+        selected_yaml = remote_yaml
+
+    return selected_path, selected_yaml
+
+
+def _write_yaml(path: Path, yaml_content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml_content)
+
+
+def _stage_and_commit_if_needed(
+    repo_root: Path,
+    relative_path: str,
+    selector: PipelineSelector,
+) -> None:
+    ok, status_output = run_git_command(["status", "--porcelain", "--", relative_path], repo_root)
+    if not ok:
+        typer.echo(red("❌ Migrate failed: could not inspect git status"))
+        if status_output:
+            typer.echo(yellow(status_output))
+        raise typer.Exit(code=1)
+
+    if not status_output:
+        return
+
+    ok, add_output = run_git_command(["add", "--", relative_path], repo_root)
+    if not ok:
+        typer.echo(red("❌ Migrate failed: could not stage YAML file"))
+        if add_output:
+            typer.echo(yellow(add_output))
+        raise typer.Exit(code=1)
+
+    pipeline_name = selector.alias or selector.pipeline_id or Path(relative_path).stem
+    commit_message = f"Migrate pipeline '{pipeline_name}' to git-backed storage"
+    ok, commit_output = run_git_command(["commit", "-m", commit_message], repo_root)
+    if ok:
+        return
+
+    if "nothing to commit" in commit_output.lower():
+        return
+
+    typer.echo(red("❌ Migrate failed: could not commit YAML file"))
+    if commit_output:
+        typer.echo(yellow(commit_output))
+    raise typer.Exit(code=1)
+
+
+def _prompt_branch_recovery(suggested_branch: str) -> bool:
+    typer.echo(yellow(f"Suggested branch for retry: {suggested_branch}"))
+    typer.echo(bold(yellow("Create and push this branch now? [Y/n]")))
+    try:
+        response = input().strip().lower()
+    except KeyboardInterrupt:
+        typer.echo(red("Aborted"))
+        raise typer.Exit(code=1)
+    return response in ("", "y", "yes")
+
+
+def _push_branch(repo_root: Path, branch_name: str) -> tuple[bool, str]:
+    has_upstream, _ = run_git_command(
+        ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
+        repo_root,
+    )
+    push_args = ["push"] if has_upstream else ["push", "-u", "origin", branch_name]
+    return run_git_command(push_args, repo_root)
+
+
+def _push_migration_branch(repo_root: Path, branch_name: str) -> str:
+    ok, push_output = _push_branch(repo_root, branch_name)
+    if ok:
+        return branch_name
+
+    if not is_branch_protection_error(push_output):
+        typer.echo(red("❌ Migrate failed: could not push changes to git"))
+        if push_output:
+            typer.echo(yellow(push_output))
+        raise typer.Exit(code=1)
+
+    typer.echo(red("❌ Push was blocked by branch protection on the current branch."))
+    if push_output:
+        typer.echo(yellow(push_output))
+
+    suggested_branch = suggest_migration_branch_name()
+    if not _prompt_branch_recovery(suggested_branch):
+        typer.echo(red("Aborted migration because the YAML was not pushed to git"))
+        raise typer.Exit(code=1)
+
+    ok, checkout_output = run_git_command(["checkout", "-b", suggested_branch], repo_root)
+    if not ok:
+        typer.echo(red(f"❌ Migrate failed: could not create branch '{suggested_branch}'"))
+        if checkout_output:
+            typer.echo(yellow(checkout_output))
+        raise typer.Exit(code=1)
+
+    ok, retry_push_output = run_git_command(["push", "-u", "origin", suggested_branch], repo_root)
+    if not ok:
+        typer.echo(red(f"❌ Migrate failed: could not push branch '{suggested_branch}'"))
+        if retry_push_output:
+            typer.echo(yellow(retry_push_output))
+        raise typer.Exit(code=1)
+
+    return suggested_branch
+
+
+def migrate_pipeline(
+    path: Path = migrate_path_option(),
+    alias: str | None = pipeline_alias_option(),
+    pipeline_id: str | None = pipeline_id_option(),
+    working_branch: str | None = typer.Option(
+        None,
+        "--working-branch",
+        help="Working branch to store in Orchestra (defaults to current branch)",
+    ),
+    default_branch: str | None = typer.Option(
+        None,
+        "--default-branch",
+        help="Default branch to store in Orchestra (defaults to git remote default branch)",
+    ),
+) -> None:
+    """
+    Migrate an Orchestra-backed pipeline to git-backed storage.
+    """
+    api_key = require_api_key()
+    selector = _resolve_migrate_selector(alias, pipeline_id)
+
+    repo_root = detect_repo_root(path.parent)
+    if repo_root is None:
+        typer.echo(red("Not a git repository (could not detect repository root)"))
+        raise typer.Exit(code=1)
+
+    repository_slug = detect_repository_slug(repo_root)
+    if not repository_slug:
+        typer.echo(red("Could not detect repository URL from git"))
+        raise typer.Exit(code=1)
+
+    if not default_branch:
+        default_branch = detect_default_branch(repo_root)
+        if not default_branch:
+            typer.echo(red("Could not detect default branch from git"))
+            raise typer.Exit(code=1)
+
+    current_branch = detect_current_branch(repo_root, allow_detached=False)
+    if not current_branch:
+        typer.echo(red("Could not detect current branch from git"))
+        raise typer.Exit(code=1)
+
+    existing_pipeline = _lookup_pipeline(selector, api_key)
+    provider = (storage_provider(existing_pipeline) or "ORCHESTRA").upper()
+    if provider != "ORCHESTRA":
+        typer.echo(red("Pipeline is already git-backed; only Orchestra-backed pipelines can be migrated"))
+        raise typer.Exit(code=1)
+
+    target_version = _choose_migration_version(existing_pipeline)
+    downloaded_yaml = _download_pipeline_yaml(selector, target_version, api_key)
+    target_path, selected_yaml = _resolve_target_path_and_yaml(path, downloaded_yaml)
+    _write_yaml(target_path, selected_yaml)
+
+    relative_path = ensure_repo_relative_path(target_path, repo_root, "Migrate")
+    _stage_and_commit_if_needed(repo_root, relative_path, selector)
+    pushed_branch = _push_migration_branch(repo_root, current_branch)
+
+    storage_provider_value = detect_storage_provider(get_remote_url(repo_root))
+    if not storage_provider_value:
+        typer.echo(red("Could not detect storage provider - no matching host"))
+        raise typer.Exit(code=1)
+
+    effective_working_branch = working_branch or pushed_branch
+    payload: dict[str, str] = {
+        "path": relative_path,
+        "repository": repository_slug,
+        "storage_provider": storage_provider_value,
+        "default_branch": default_branch,
+    }
+    if effective_working_branch != default_branch:
+        payload["working_branch"] = effective_working_branch
+
+    response = request_or_exit(
+        httpx.patch,
+        get_api_url("pipelines/storage-settings"),
+        params=selector.to_payload(),
+        json=payload,
+        timeout=30,
+        headers=auth_headers(api_key),
+    )
+    if not (200 <= response.status_code < 300):
+        raise fail_with_response("Migrate", response)
+
+    typer.echo(
+        green(
+            "✅ Migrated pipeline "
+            f"({selector.display()}) to git-backed storage at '{relative_path}'",
+        ),
+    )
+
+    if pushed_branch != default_branch:
+        compare_link = build_compare_link(
+            storage_provider_value,
+            repository_slug,
+            default_branch,
+            pushed_branch,
+        )
+        if compare_link:
+            typer.echo(yellow(f"Open PR / compare link: {compare_link}"))
+        else:
+            typer.echo(
+                yellow(
+                    f"Pushed to branch '{pushed_branch}'. Open a PR against '{default_branch}'.",
+                ),
+            )
+
+    raise typer.Exit(code=0)

--- a/orchestra_cli/src/migrate_pipeline.py
+++ b/orchestra_cli/src/migrate_pipeline.py
@@ -47,7 +47,7 @@ def _resolve_migrate_selector(alias: str | None, pipeline_id: str | None) -> Pip
     if pipeline_id:
         return PipelineSelector(pipeline_id=pipeline_id)
 
-    typer.echo(red("Provide one of --alias or --pipeline-id"))
+    typer.echo(red("Provide a pipeline alias or pipeline ID"))
     raise typer.Exit(code=1)
 
 
@@ -394,9 +394,8 @@ def migrate_pipeline(
     target_version = _choose_migration_version(existing_pipeline, force)
     downloaded_yaml = _download_pipeline_yaml(selector, target_version, api_key)
     target_path, selected_yaml = _resolve_target_path_and_yaml(path, downloaded_yaml, force)
-    _write_yaml(target_path, selected_yaml)
-
     relative_path = ensure_repo_relative_path(target_path, repo_root, GitAction.MIGRATE)
+    _write_yaml(target_path, selected_yaml)
     pipeline_name = selector.alias or selector.pipeline_id or Path(relative_path).stem
     commit_was_created = stage_and_commit_file_if_needed(
         repo_root,

--- a/orchestra_cli/src/migrate_pipeline.py
+++ b/orchestra_cli/src/migrate_pipeline.py
@@ -278,7 +278,23 @@ def _prompt_branch_recovery(suggested_branch: str, force: bool) -> bool:
     return response in ("", "y", "yes")
 
 
-def _push_migration_branch(repo_root: Path, branch_name: str, force: bool) -> str:
+def _reset_original_branch_ref(repo_root: Path, branch_name: str) -> None:
+    ok, reset_output = run_git_command(["branch", "-f", branch_name, "HEAD~1"], repo_root)
+    if ok:
+        return
+
+    typer.echo(red(f"❌ Migrate failed: could not restore branch '{branch_name}' after retrying"))
+    if reset_output:
+        typer.echo(yellow(reset_output))
+    raise typer.Exit(code=1)
+
+
+def _push_migration_branch(
+    repo_root: Path,
+    branch_name: str,
+    force: bool,
+    commit_was_created: bool,
+) -> str:
     ok, push_output = push_branch(repo_root, branch_name)
     if ok:
         return branch_name
@@ -304,6 +320,9 @@ def _push_migration_branch(repo_root: Path, branch_name: str, force: bool) -> st
         if checkout_output:
             typer.echo(yellow(checkout_output))
         raise typer.Exit(code=1)
+
+    if commit_was_created:
+        _reset_original_branch_ref(repo_root, branch_name)
 
     ok, retry_push_output = push_branch(repo_root, suggested_branch)
     if not ok:
@@ -379,13 +398,13 @@ def migrate_pipeline(
 
     relative_path = ensure_repo_relative_path(target_path, repo_root, GitAction.MIGRATE)
     pipeline_name = selector.alias or selector.pipeline_id or Path(relative_path).stem
-    stage_and_commit_file_if_needed(
+    commit_was_created = stage_and_commit_file_if_needed(
         repo_root,
         relative_path,
         f"Migrate pipeline '{pipeline_name}' to git-backed storage",
         GitAction.MIGRATE,
     )
-    pushed_branch = _push_migration_branch(repo_root, current_branch, force)
+    pushed_branch = _push_migration_branch(repo_root, current_branch, force, commit_was_created)
 
     effective_working_branch = working_branch or pushed_branch
     payload: dict[str, str] = {

--- a/orchestra_cli/src/update_pipeline.py
+++ b/orchestra_cli/src/update_pipeline.py
@@ -10,7 +10,7 @@ from ..utils.api import (
     require_api_key,
 )
 from ..utils.constants import get_pipeline_url, get_update_pipeline_url
-from ..utils.git import prepare_git_backed_run_target
+from ..utils.git import GitAction, prepare_git_backed_run_target
 from ..utils.pipeline_selector import (
     PipelineSelector,
     pipeline_alias_option,
@@ -80,7 +80,7 @@ def update_pipeline(
             path=path,
             existing_pipeline=existing_pipeline,
             force=force,
-            action="Update",
+            action=GitAction.UPDATE,
         )
         typer.echo(
             green(

--- a/orchestra_cli/tests/test_build_pipeline.py
+++ b/orchestra_cli/tests/test_build_pipeline.py
@@ -669,7 +669,9 @@ def test_build_git_backed_push_failure_can_retry_on_new_branch(
         if key == ("status", "--porcelain", "--", "pipe.yaml"):
             return Result(0, " M pipe.yaml", "")
         if key == ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"):
-            return Result(0, "origin/main", "")
+            if current_branch == "main":
+                return Result(0, "origin/main", "")
+            return Result(1, "", "fatal: no upstream")
         if key == ("rev-list", "--left-right", "--count", "@{u}...HEAD"):
             return Result(0, "0 0", "")
         if key == ("rev-parse", "--abbrev-ref", "HEAD"):
@@ -777,7 +779,9 @@ def test_build_git_backed_force_auto_accepts_branch_retry(
         if key == ("status", "--porcelain", "--", "pipe.yaml"):
             return Result(0, " M pipe.yaml", "")
         if key == ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"):
-            return Result(0, "origin/main", "")
+            if current_branch == "main":
+                return Result(0, "origin/main", "")
+            return Result(1, "", "fatal: no upstream")
         if key == ("rev-list", "--left-right", "--count", "@{u}...HEAD"):
             return Result(0, "0 0", "")
         if key == ("rev-parse", "--abbrev-ref", "HEAD"):

--- a/orchestra_cli/tests/test_cli.py
+++ b/orchestra_cli/tests/test_cli.py
@@ -16,7 +16,18 @@ def test_help():
 def test_pipeline_help_lists_verbs():
     result = runner.invoke(app, ["pipeline", "--help"])
     assert result.exit_code == 0
-    for verb in ("validate", "import", "new", "update", "get", "list", "run", "build", "delete"):
+    for verb in (
+        "validate",
+        "import",
+        "new",
+        "update",
+        "get",
+        "list",
+        "run",
+        "build",
+        "delete",
+        "migrate",
+    ):
         assert verb in result.output
 
 

--- a/orchestra_cli/tests/test_migrate_pipeline.py
+++ b/orchestra_cli/tests/test_migrate_pipeline.py
@@ -1,0 +1,305 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+from pytest_httpx import HTTPXMock
+from typer.testing import CliRunner
+
+from orchestra_cli.src.cli import app
+from orchestra_cli.utils import git as git_module
+from tests.conftest import make_git_subprocess_mock
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def mock_env(monkeypatch):
+    monkeypatch.setenv("ORCHESTRA_API_KEY", "fake-key")
+    monkeypatch.setenv("BASE_URL", "")
+
+
+def test_migrate_success_uses_default_branch_without_working_branch(
+    monkeypatch,
+    tmp_path: Path,
+    httpx_mock: HTTPXMock,
+):
+    target_file = tmp_path / "pipelines" / "demo.yaml"
+
+    httpx_mock.add_response(
+        method="GET",
+        url="https://app.getorchestra.io/api/engine/public/pipeline?alias=demo",
+        json={
+            "id": "pipeline-id",
+            "alias": "demo",
+            "storage_provider": "ORCHESTRA",
+            "publishedVersionNumber": 3,
+            "latestVersionNumber": 3,
+        },
+        status_code=200,
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url="https://app.getorchestra.io/api/engine/public/pipeline/data?alias=demo&version=3",
+        text="name: remote\nversion: 1\n",
+        status_code=200,
+    )
+    httpx_mock.add_response(
+        method="PATCH",
+        url="https://app.getorchestra.io/api/engine/public/pipelines/storage-settings?alias=demo",
+        json={"ok": True},
+        status_code=200,
+        match_json={
+            "path": "pipelines/demo.yaml",
+            "repository": "org/repo",
+            "storage_provider": "GITHUB",
+            "default_branch": "main",
+        },
+    )
+
+    mapping = {
+        ("rev-parse", "--show-toplevel"): (0, str(tmp_path), ""),
+        ("remote", "get-url", "origin"): (0, "git@github.com:org/repo.git", ""),
+        ("symbolic-ref", "refs/remotes/origin/HEAD"): (0, "refs/remotes/origin/main", ""),
+        ("rev-parse", "--abbrev-ref", "HEAD"): (0, "main", ""),
+        ("status", "--porcelain", "--", "pipelines/demo.yaml"): (0, "?? pipelines/demo.yaml", ""),
+        ("add", "--", "pipelines/demo.yaml"): (0, "", ""),
+        ("commit", "-m", "Migrate pipeline 'demo' to git-backed storage"): (0, "", ""),
+        ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"): (1, "", ""),
+        ("push", "-u", "origin", "main"): (0, "", ""),
+    }
+    monkeypatch.setattr(subprocess, "run", make_git_subprocess_mock(mapping))
+
+    result = runner.invoke(
+        app,
+        ["pipeline", "migrate", "--alias", "demo", "--path", str(target_file)],
+    )
+
+    assert result.exit_code == 0
+    assert "migrated pipeline" in result.output.lower()
+    assert "compare link" not in result.output.lower()
+    assert target_file.read_text() == "name: remote\nversion: 1\n"
+
+
+def test_migrate_prompts_for_latest_version_and_prints_compare_link(
+    monkeypatch,
+    tmp_path: Path,
+    httpx_mock: HTTPXMock,
+):
+    target_file = tmp_path / "pipelines" / "demo.yaml"
+
+    httpx_mock.add_response(
+        method="GET",
+        url="https://app.getorchestra.io/api/engine/public/pipeline?alias=demo",
+        json={
+            "id": "pipeline-id",
+            "alias": "demo",
+            "storage_provider": "ORCHESTRA",
+            "publishedVersionNumber": 2,
+            "latestVersionNumber": 5,
+        },
+        status_code=200,
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url="https://app.getorchestra.io/api/engine/public/pipeline/data?alias=demo&version=5",
+        text="name: remote\n",
+        status_code=200,
+    )
+    httpx_mock.add_response(
+        method="PATCH",
+        url="https://app.getorchestra.io/api/engine/public/pipelines/storage-settings?alias=demo",
+        json={"ok": True},
+        status_code=200,
+        match_json={
+            "path": "pipelines/demo.yaml",
+            "repository": "org/repo",
+            "storage_provider": "GITHUB",
+            "default_branch": "main",
+            "working_branch": "feature/migrate",
+        },
+    )
+
+    mapping = {
+        ("rev-parse", "--show-toplevel"): (0, str(tmp_path), ""),
+        ("remote", "get-url", "origin"): (0, "git@github.com:org/repo.git", ""),
+        ("symbolic-ref", "refs/remotes/origin/HEAD"): (0, "refs/remotes/origin/main", ""),
+        ("rev-parse", "--abbrev-ref", "HEAD"): (0, "feature/migrate", ""),
+        ("status", "--porcelain", "--", "pipelines/demo.yaml"): (0, "?? pipelines/demo.yaml", ""),
+        ("add", "--", "pipelines/demo.yaml"): (0, "", ""),
+        ("commit", "-m", "Migrate pipeline 'demo' to git-backed storage"): (0, "", ""),
+        ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"): (0, "origin/feature/migrate", ""),
+        ("push",): (0, "", ""),
+    }
+    monkeypatch.setattr(subprocess, "run", make_git_subprocess_mock(mapping))
+
+    result = runner.invoke(
+        app,
+        ["pipeline", "migrate", "--alias", "demo", "--path", str(target_file)],
+        input="\n",
+    )
+
+    assert result.exit_code == 0
+    assert "Select 1 or 2" in result.output
+    assert "Open PR / compare link" in result.output
+    assert "github.com/org/repo/compare/main...feature/migrate" in result.output
+
+
+def test_migrate_uses_local_file_when_conflict_choice_is_local(
+    monkeypatch,
+    tmp_path: Path,
+    httpx_mock: HTTPXMock,
+):
+    target_file = tmp_path / "pipelines" / "demo.yaml"
+    target_file.parent.mkdir(parents=True, exist_ok=True)
+    target_file.write_text("name: local\n")
+
+    httpx_mock.add_response(
+        method="GET",
+        url="https://app.getorchestra.io/api/engine/public/pipeline?alias=demo",
+        json={
+            "id": "pipeline-id",
+            "alias": "demo",
+            "storage_provider": "ORCHESTRA",
+            "publishedVersionNumber": 1,
+            "latestVersionNumber": 1,
+        },
+        status_code=200,
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url="https://app.getorchestra.io/api/engine/public/pipeline/data?alias=demo&version=1",
+        text="name: remote\n",
+        status_code=200,
+    )
+    httpx_mock.add_response(
+        method="PATCH",
+        url="https://app.getorchestra.io/api/engine/public/pipelines/storage-settings?alias=demo",
+        json={"ok": True},
+        status_code=200,
+        match_json={
+            "path": "pipelines/demo.yaml",
+            "repository": "org/repo",
+            "storage_provider": "GITHUB",
+            "default_branch": "main",
+            "working_branch": "feature/local",
+        },
+    )
+
+    mapping = {
+        ("rev-parse", "--show-toplevel"): (0, str(tmp_path), ""),
+        ("remote", "get-url", "origin"): (0, "git@github.com:org/repo.git", ""),
+        ("symbolic-ref", "refs/remotes/origin/HEAD"): (0, "refs/remotes/origin/main", ""),
+        ("rev-parse", "--abbrev-ref", "HEAD"): (0, "feature/local", ""),
+        ("status", "--porcelain", "--", "pipelines/demo.yaml"): (0, "", ""),
+        ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"): (0, "origin/feature/local", ""),
+        ("push",): (0, "", ""),
+    }
+    monkeypatch.setattr(subprocess, "run", make_git_subprocess_mock(mapping))
+
+    result = runner.invoke(
+        app,
+        ["pipeline", "migrate", "--alias", "demo", "--path", str(target_file)],
+        input="2\n",
+    )
+
+    assert result.exit_code == 0
+    assert "Local file differs from Orchestra YAML" in result.output
+    assert target_file.read_text() == "name: local\n"
+
+
+def test_migrate_fails_when_pipeline_is_already_git_backed(
+    monkeypatch,
+    tmp_path: Path,
+    httpx_mock: HTTPXMock,
+):
+    target_file = tmp_path / "pipelines" / "demo.yaml"
+
+    httpx_mock.add_response(
+        method="GET",
+        url="https://app.getorchestra.io/api/engine/public/pipeline?alias=demo",
+        json={"id": "pipeline-id", "alias": "demo", "storage_provider": "GITHUB"},
+        status_code=200,
+    )
+
+    mapping = {
+        ("rev-parse", "--show-toplevel"): (0, str(tmp_path), ""),
+        ("remote", "get-url", "origin"): (0, "git@github.com:org/repo.git", ""),
+        ("symbolic-ref", "refs/remotes/origin/HEAD"): (0, "refs/remotes/origin/main", ""),
+        ("rev-parse", "--abbrev-ref", "HEAD"): (0, "feature/migrate", ""),
+    }
+    monkeypatch.setattr(subprocess, "run", make_git_subprocess_mock(mapping))
+
+    result = runner.invoke(
+        app,
+        ["pipeline", "migrate", "--alias", "demo", "--path", str(target_file)],
+    )
+
+    assert result.exit_code == 1
+    assert "already git-backed" in result.output
+
+
+def test_migrate_branch_protection_offer_retries_with_suggested_branch(
+    monkeypatch,
+    tmp_path: Path,
+    httpx_mock: HTTPXMock,
+):
+    target_file = tmp_path / "pipelines" / "demo.yaml"
+    suggested_branch = "orchestra-migrate-pipeline-ABC123"
+    monkeypatch.setattr(git_module, "suggest_migration_branch_name", lambda: suggested_branch)
+
+    httpx_mock.add_response(
+        method="GET",
+        url="https://app.getorchestra.io/api/engine/public/pipeline?alias=demo",
+        json={
+            "id": "pipeline-id",
+            "alias": "demo",
+            "storage_provider": "ORCHESTRA",
+            "publishedVersionNumber": 1,
+            "latestVersionNumber": 1,
+        },
+        status_code=200,
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url="https://app.getorchestra.io/api/engine/public/pipeline/data?alias=demo&version=1",
+        text="name: remote\n",
+        status_code=200,
+    )
+    httpx_mock.add_response(
+        method="PATCH",
+        url="https://app.getorchestra.io/api/engine/public/pipelines/storage-settings?alias=demo",
+        json={"ok": True},
+        status_code=200,
+        match_json={
+            "path": "pipelines/demo.yaml",
+            "repository": "org/repo",
+            "storage_provider": "GITHUB",
+            "default_branch": "main",
+            "working_branch": suggested_branch,
+        },
+    )
+
+    mapping = {
+        ("rev-parse", "--show-toplevel"): (0, str(tmp_path), ""),
+        ("remote", "get-url", "origin"): (0, "git@github.com:org/repo.git", ""),
+        ("symbolic-ref", "refs/remotes/origin/HEAD"): (0, "refs/remotes/origin/main", ""),
+        ("rev-parse", "--abbrev-ref", "HEAD"): (0, "main", ""),
+        ("status", "--porcelain", "--", "pipelines/demo.yaml"): (0, "?? pipelines/demo.yaml", ""),
+        ("add", "--", "pipelines/demo.yaml"): (0, "", ""),
+        ("commit", "-m", "Migrate pipeline 'demo' to git-backed storage"): (0, "", ""),
+        ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"): (0, "origin/main", ""),
+        ("push",): (1, "", "remote: push blocked by branch protection"),
+        ("checkout", "-b", suggested_branch): (0, "", ""),
+        ("push", "-u", "origin", suggested_branch): (0, "", ""),
+    }
+    monkeypatch.setattr(subprocess, "run", make_git_subprocess_mock(mapping))
+
+    result = runner.invoke(
+        app,
+        ["pipeline", "migrate", "--alias", "demo", "--path", str(target_file)],
+        input="\n",
+    )
+
+    assert result.exit_code == 0
+    assert "branch protection" in result.output.lower()
+    assert suggested_branch in result.output

--- a/orchestra_cli/tests/test_migrate_pipeline.py
+++ b/orchestra_cli/tests/test_migrate_pipeline.py
@@ -448,3 +448,27 @@ def test_migrate_force_skips_branch_recovery_prompt(
 
     assert result.exit_code == 0
     assert "--force set; retrying push on suggested branch" in result.output
+
+
+def test_migrate_fails_before_git_write_when_storage_provider_is_unsupported(
+    monkeypatch,
+    tmp_path: Path,
+    httpx_mock: HTTPXMock,
+):
+    del httpx_mock
+    target_file = tmp_path / "pipelines" / "demo.yaml"
+
+    mapping = {
+        ("rev-parse", "--show-toplevel"): (0, str(tmp_path), ""),
+        ("remote", "get-url", "origin"): (0, "git@gitea.example.com:org/repo.git", ""),
+    }
+    monkeypatch.setattr(subprocess, "run", make_git_subprocess_mock(mapping))
+
+    result = runner.invoke(
+        app,
+        ["pipeline", "migrate", "--alias", "demo", "--path", str(target_file)],
+    )
+
+    assert result.exit_code == 1
+    assert "Could not detect storage provider - no matching host" in result.output
+    assert not target_file.exists()

--- a/orchestra_cli/tests/test_migrate_pipeline.py
+++ b/orchestra_cli/tests/test_migrate_pipeline.py
@@ -313,3 +313,138 @@ def test_migrate_branch_protection_offer_retries_with_suggested_branch(
     assert result.exit_code == 0
     assert "branch protection" in result.output.lower()
     assert suggested_branch in result.output
+
+
+def test_migrate_force_skips_version_prompt(monkeypatch, tmp_path: Path, httpx_mock: HTTPXMock):
+    target_file = tmp_path / "pipelines" / "demo.yaml"
+
+    def fail_input() -> str:
+        raise AssertionError("input should not be called when --force is set")
+
+    monkeypatch.setattr("builtins.input", fail_input)
+
+    httpx_mock.add_response(
+        method="GET",
+        url="https://app.getorchestra.io/api/engine/public/pipeline?alias=demo",
+        json={
+            "id": "pipeline-id",
+            "alias": "demo",
+            "storage_provider": "ORCHESTRA",
+            "publishedVersionNumber": 1,
+            "latestVersionNumber": 2,
+        },
+        status_code=200,
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url="https://app.getorchestra.io/api/engine/public/pipeline/data?alias=demo&version=2",
+        text="name: remote\n",
+        status_code=200,
+    )
+    httpx_mock.add_response(
+        method="PATCH",
+        url="https://app.getorchestra.io/api/engine/public/pipelines/storage-settings?alias=demo",
+        json={"ok": True},
+        status_code=200,
+        match_json={
+            "path": "pipelines/demo.yaml",
+            "repository": "org/repo",
+            "storage_provider": "GITHUB",
+            "default_branch": "main",
+            "working_branch": "feature/force",
+        },
+    )
+
+    mapping = {
+        ("rev-parse", "--show-toplevel"): (0, str(tmp_path), ""),
+        ("remote", "get-url", "origin"): (0, "git@github.com:org/repo.git", ""),
+        ("symbolic-ref", "refs/remotes/origin/HEAD"): (0, "refs/remotes/origin/main", ""),
+        ("rev-parse", "--abbrev-ref", "HEAD"): (0, "feature/force", ""),
+        ("status", "--porcelain", "--", "pipelines/demo.yaml"): (0, "?? pipelines/demo.yaml", ""),
+        ("add", "--", "pipelines/demo.yaml"): (0, "", ""),
+        ("commit", "-m", "Migrate pipeline 'demo' to git-backed storage"): (0, "", ""),
+        ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"): (1, "", ""),
+        ("push", "-u", "origin", "feature/force"): (0, "", ""),
+    }
+    monkeypatch.setattr(subprocess, "run", make_git_subprocess_mock(mapping))
+
+    result = runner.invoke(
+        app,
+        ["pipeline", "migrate", "--alias", "demo", "--path", str(target_file), "--force"],
+    )
+
+    assert result.exit_code == 0
+    assert "--force selected latest version" in result.output
+
+
+def test_migrate_force_skips_branch_recovery_prompt(
+    monkeypatch,
+    tmp_path: Path,
+    httpx_mock: HTTPXMock,
+):
+    target_file = tmp_path / "pipelines" / "demo.yaml"
+    suggested_branch = "orchestra-migrate-pipeline-FORCE1"
+    monkeypatch.setattr(
+        "orchestra_cli.src.migrate_pipeline.suggest_migration_branch_name",
+        lambda: suggested_branch,
+    )
+
+    def fail_input() -> str:
+        raise AssertionError("input should not be called when --force is set")
+
+    monkeypatch.setattr("builtins.input", fail_input)
+
+    httpx_mock.add_response(
+        method="GET",
+        url="https://app.getorchestra.io/api/engine/public/pipeline?alias=demo",
+        json={
+            "id": "pipeline-id",
+            "alias": "demo",
+            "storage_provider": "ORCHESTRA",
+            "publishedVersionNumber": 1,
+            "latestVersionNumber": 1,
+        },
+        status_code=200,
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url="https://app.getorchestra.io/api/engine/public/pipeline/data?alias=demo&version=1",
+        text="name: remote\n",
+        status_code=200,
+    )
+    httpx_mock.add_response(
+        method="PATCH",
+        url="https://app.getorchestra.io/api/engine/public/pipelines/storage-settings?alias=demo",
+        json={"ok": True},
+        status_code=200,
+        match_json={
+            "path": "pipelines/demo.yaml",
+            "repository": "org/repo",
+            "storage_provider": "GITHUB",
+            "default_branch": "main",
+            "working_branch": suggested_branch,
+        },
+    )
+
+    mapping = {
+        ("rev-parse", "--show-toplevel"): (0, str(tmp_path), ""),
+        ("remote", "get-url", "origin"): (0, "git@github.com:org/repo.git", ""),
+        ("symbolic-ref", "refs/remotes/origin/HEAD"): (0, "refs/remotes/origin/main", ""),
+        ("rev-parse", "--abbrev-ref", "HEAD"): (0, "main", ""),
+        ("status", "--porcelain", "--", "pipelines/demo.yaml"): (0, "?? pipelines/demo.yaml", ""),
+        ("add", "--", "pipelines/demo.yaml"): (0, "", ""),
+        ("commit", "-m", "Migrate pipeline 'demo' to git-backed storage"): (0, "", ""),
+        ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"): (0, "origin/main", ""),
+        ("push",): (1, "", "remote: push blocked by branch protection"),
+        ("checkout", "-b", suggested_branch): (0, "", ""),
+        ("push", "-u", "origin", suggested_branch): (0, "", ""),
+    }
+    monkeypatch.setattr(subprocess, "run", make_git_subprocess_mock(mapping))
+
+    result = runner.invoke(
+        app,
+        ["pipeline", "migrate", "--alias", "demo", "--path", str(target_file), "--force"],
+    )
+
+    assert result.exit_code == 0
+    assert "--force set; retrying push on suggested branch" in result.output

--- a/orchestra_cli/tests/test_migrate_pipeline.py
+++ b/orchestra_cli/tests/test_migrate_pipeline.py
@@ -6,7 +6,6 @@ from pytest_httpx import HTTPXMock
 from typer.testing import CliRunner
 
 from orchestra_cli.src.cli import app
-from orchestra_cli.utils import git as git_module
 from tests.conftest import make_git_subprocess_mock
 
 runner = CliRunner()
@@ -127,7 +126,11 @@ def test_migrate_prompts_for_latest_version_and_prints_compare_link(
         ("status", "--porcelain", "--", "pipelines/demo.yaml"): (0, "?? pipelines/demo.yaml", ""),
         ("add", "--", "pipelines/demo.yaml"): (0, "", ""),
         ("commit", "-m", "Migrate pipeline 'demo' to git-backed storage"): (0, "", ""),
-        ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"): (0, "origin/feature/migrate", ""),
+        ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"): (
+            0,
+            "origin/feature/migrate",
+            "",
+        ),
         ("push",): (0, "", ""),
     }
     monkeypatch.setattr(subprocess, "run", make_git_subprocess_mock(mapping))
@@ -191,7 +194,11 @@ def test_migrate_uses_local_file_when_conflict_choice_is_local(
         ("symbolic-ref", "refs/remotes/origin/HEAD"): (0, "refs/remotes/origin/main", ""),
         ("rev-parse", "--abbrev-ref", "HEAD"): (0, "feature/local", ""),
         ("status", "--porcelain", "--", "pipelines/demo.yaml"): (0, "", ""),
-        ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"): (0, "origin/feature/local", ""),
+        ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"): (
+            0,
+            "origin/feature/local",
+            "",
+        ),
         ("push",): (0, "", ""),
     }
     monkeypatch.setattr(subprocess, "run", make_git_subprocess_mock(mapping))
@@ -245,7 +252,10 @@ def test_migrate_branch_protection_offer_retries_with_suggested_branch(
 ):
     target_file = tmp_path / "pipelines" / "demo.yaml"
     suggested_branch = "orchestra-migrate-pipeline-ABC123"
-    monkeypatch.setattr(git_module, "suggest_migration_branch_name", lambda: suggested_branch)
+    monkeypatch.setattr(
+        "orchestra_cli.src.migrate_pipeline.suggest_migration_branch_name",
+        lambda: suggested_branch,
+    )
 
     httpx_mock.add_response(
         method="GET",

--- a/orchestra_cli/tests/test_migrate_pipeline.py
+++ b/orchestra_cli/tests/test_migrate_pipeline.py
@@ -300,6 +300,7 @@ def test_migrate_branch_protection_offer_retries_with_suggested_branch(
         ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"): (0, "origin/main", ""),
         ("push",): (1, "", "remote: push blocked by branch protection"),
         ("checkout", "-b", suggested_branch): (0, "", ""),
+        ("branch", "-f", "main", "HEAD~1"): (0, "", ""),
         ("push", "-u", "origin", suggested_branch): (0, "", ""),
     }
     monkeypatch.setattr(subprocess, "run", make_git_subprocess_mock(mapping))
@@ -313,6 +314,66 @@ def test_migrate_branch_protection_offer_retries_with_suggested_branch(
     assert result.exit_code == 0
     assert "branch protection" in result.output.lower()
     assert suggested_branch in result.output
+
+
+def test_migrate_accepts_nonexistent_parent_directory_inside_repo(
+    monkeypatch,
+    tmp_path: Path,
+    httpx_mock: HTTPXMock,
+):
+    target_file = tmp_path / "new-subdir" / "demo.yaml"
+
+    httpx_mock.add_response(
+        method="GET",
+        url="https://app.getorchestra.io/api/engine/public/pipeline?alias=demo",
+        json={
+            "id": "pipeline-id",
+            "alias": "demo",
+            "storage_provider": "ORCHESTRA",
+            "publishedVersionNumber": 1,
+            "latestVersionNumber": 1,
+        },
+        status_code=200,
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url="https://app.getorchestra.io/api/engine/public/pipeline/data?alias=demo&version=1",
+        text="name: remote\n",
+        status_code=200,
+    )
+    httpx_mock.add_response(
+        method="PATCH",
+        url="https://app.getorchestra.io/api/engine/public/pipelines/storage-settings?alias=demo",
+        json={"ok": True},
+        status_code=200,
+        match_json={
+            "path": "new-subdir/demo.yaml",
+            "repository": "org/repo",
+            "storage_provider": "GITHUB",
+            "default_branch": "main",
+        },
+    )
+
+    mapping = {
+        ("rev-parse", "--show-toplevel"): (0, str(tmp_path), ""),
+        ("remote", "get-url", "origin"): (0, "git@github.com:org/repo.git", ""),
+        ("symbolic-ref", "refs/remotes/origin/HEAD"): (0, "refs/remotes/origin/main", ""),
+        ("rev-parse", "--abbrev-ref", "HEAD"): (0, "main", ""),
+        ("status", "--porcelain", "--", "new-subdir/demo.yaml"): (0, "?? new-subdir/demo.yaml", ""),
+        ("add", "--", "new-subdir/demo.yaml"): (0, "", ""),
+        ("commit", "-m", "Migrate pipeline 'demo' to git-backed storage"): (0, "", ""),
+        ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"): (1, "", ""),
+        ("push", "-u", "origin", "main"): (0, "", ""),
+    }
+    monkeypatch.setattr(subprocess, "run", make_git_subprocess_mock(mapping))
+
+    result = runner.invoke(
+        app,
+        ["pipeline", "migrate", "--alias", "demo", "--path", str(target_file)],
+    )
+
+    assert result.exit_code == 0
+    assert target_file.read_text() == "name: remote\n"
 
 
 def test_migrate_force_skips_version_prompt(monkeypatch, tmp_path: Path, httpx_mock: HTTPXMock):
@@ -437,6 +498,7 @@ def test_migrate_force_skips_branch_recovery_prompt(
         ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"): (0, "origin/main", ""),
         ("push",): (1, "", "remote: push blocked by branch protection"),
         ("checkout", "-b", suggested_branch): (0, "", ""),
+        ("branch", "-f", "main", "HEAD~1"): (0, "", ""),
         ("push", "-u", "origin", suggested_branch): (0, "", ""),
     }
     monkeypatch.setattr(subprocess, "run", make_git_subprocess_mock(mapping))

--- a/orchestra_cli/tests/test_migrate_pipeline.py
+++ b/orchestra_cli/tests/test_migrate_pipeline.py
@@ -512,6 +512,54 @@ def test_migrate_force_skips_branch_recovery_prompt(
     assert "--force set; retrying push on suggested branch" in result.output
 
 
+def test_migrate_fails_before_writing_when_reprompted_path_is_outside_repo(
+    monkeypatch,
+    tmp_path: Path,
+    httpx_mock: HTTPXMock,
+):
+    target_file = tmp_path / "pipelines" / "demo.yaml"
+    target_file.parent.mkdir(parents=True, exist_ok=True)
+    target_file.write_text("name: local\n")
+    outside_file = tmp_path.parent / "outside-repo" / "demo.yaml"
+
+    httpx_mock.add_response(
+        method="GET",
+        url="https://app.getorchestra.io/api/engine/public/pipeline?alias=demo",
+        json={
+            "id": "pipeline-id",
+            "alias": "demo",
+            "storage_provider": "ORCHESTRA",
+            "publishedVersionNumber": 1,
+            "latestVersionNumber": 1,
+        },
+        status_code=200,
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url="https://app.getorchestra.io/api/engine/public/pipeline/data?alias=demo&version=1",
+        text="name: remote\n",
+        status_code=200,
+    )
+
+    mapping = {
+        ("rev-parse", "--show-toplevel"): (0, str(tmp_path), ""),
+        ("remote", "get-url", "origin"): (0, "git@github.com:org/repo.git", ""),
+        ("symbolic-ref", "refs/remotes/origin/HEAD"): (0, "refs/remotes/origin/main", ""),
+        ("rev-parse", "--abbrev-ref", "HEAD"): (0, "main", ""),
+    }
+    monkeypatch.setattr(subprocess, "run", make_git_subprocess_mock(mapping))
+
+    result = runner.invoke(
+        app,
+        ["pipeline", "migrate", "--alias", "demo", "--path", str(target_file)],
+        input=f"3\n{outside_file}\n",
+    )
+
+    assert result.exit_code == 1
+    assert "YAML file must be inside the git repository" in result.output
+    assert not outside_file.exists()
+
+
 def test_migrate_fails_before_git_write_when_storage_provider_is_unsupported(
     monkeypatch,
     tmp_path: Path,

--- a/orchestra_cli/tests/test_update_pipeline.py
+++ b/orchestra_cli/tests/test_update_pipeline.py
@@ -443,7 +443,9 @@ def test_update_git_backed_push_failure_can_retry_on_new_branch(
         if key == ("status", "--porcelain", "--", "pipe.yaml"):
             return Result(0, " M pipe.yaml", "")
         if key == ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"):
-            return Result(0, "origin/main", "")
+            if current_branch == "main":
+                return Result(0, "origin/main", "")
+            return Result(1, "", "fatal: no upstream")
         if key == ("rev-list", "--left-right", "--count", "@{u}...HEAD"):
             return Result(0, "0 0", "")
         if key == ("rev-parse", "--abbrev-ref", "HEAD"):
@@ -536,7 +538,9 @@ def test_update_git_backed_force_auto_accepts_branch_retry(
         if key == ("status", "--porcelain", "--", "pipe.yaml"):
             return Result(0, " M pipe.yaml", "")
         if key == ("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"):
-            return Result(0, "origin/main", "")
+            if current_branch == "main":
+                return Result(0, "origin/main", "")
+            return Result(1, "", "fatal: no upstream")
         if key == ("rev-list", "--left-right", "--count", "@{u}...HEAD"):
             return Result(0, "0 0", "")
         if key == ("rev-parse", "--abbrev-ref", "HEAD"):

--- a/orchestra_cli/tests/utils/test_git.py
+++ b/orchestra_cli/tests/utils/test_git.py
@@ -101,3 +101,16 @@ def test_stage_and_commit_file_if_needed_commit_failure_raises(monkeypatch, tmp_
             commit_message="test commit",
             action=git_module.GitAction.MIGRATE,
         )
+
+
+def test_require_repo_root_walks_up_from_nonexistent_parent(monkeypatch, tmp_path: Path):
+    target_file = tmp_path / "new-subdir" / "pipe.yaml"
+
+    mapping = {
+        ("rev-parse", "--show-toplevel"): (0, str(tmp_path), ""),
+    }
+    import subprocess
+
+    monkeypatch.setattr(subprocess, "run", make_git_subprocess_mock(mapping))
+
+    assert git_module.require_repo_root(target_file, git_module.GitAction.MIGRATE) == tmp_path

--- a/orchestra_cli/tests/utils/test_git.py
+++ b/orchestra_cli/tests/utils/test_git.py
@@ -80,7 +80,7 @@ def test_stage_and_commit_file_if_needed_no_changes(monkeypatch, tmp_path: Path)
         repo_root=tmp_path,
         relative_path="pipe.yaml",
         commit_message="test commit",
-        action="Migrate",
+        action=git_module.GitAction.MIGRATE,
     )
 
 
@@ -99,5 +99,5 @@ def test_stage_and_commit_file_if_needed_commit_failure_raises(monkeypatch, tmp_
             repo_root=tmp_path,
             relative_path="pipe.yaml",
             commit_message="test commit",
-            action="Migrate",
+            action=git_module.GitAction.MIGRATE,
         )

--- a/orchestra_cli/tests/utils/test_git.py
+++ b/orchestra_cli/tests/utils/test_git.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from orchestra_cli.utils import git as git_module
 from tests.conftest import make_git_subprocess_mock
 
@@ -64,3 +66,38 @@ def test_suggest_migration_branch_name_format(monkeypatch):
 
     monkeypatch.setattr(git_module.random, "choices", fake_choices)
     assert git_module.suggest_migration_branch_name() == "orchestra-migrate-pipeline-ABC123"
+
+
+def test_stage_and_commit_file_if_needed_no_changes(monkeypatch, tmp_path: Path):
+    mapping = {
+        ("status", "--porcelain", "--", "pipe.yaml"): (0, "", ""),
+    }
+    import subprocess
+
+    monkeypatch.setattr(subprocess, "run", make_git_subprocess_mock(mapping))
+
+    git_module.stage_and_commit_file_if_needed(
+        repo_root=tmp_path,
+        relative_path="pipe.yaml",
+        commit_message="test commit",
+        action="Migrate",
+    )
+
+
+def test_stage_and_commit_file_if_needed_commit_failure_raises(monkeypatch, tmp_path: Path):
+    mapping = {
+        ("status", "--porcelain", "--", "pipe.yaml"): (0, " M pipe.yaml", ""),
+        ("add", "--", "pipe.yaml"): (0, "", ""),
+        ("commit", "-m", "test commit"): (1, "", "fatal: commit failed"),
+    }
+    import subprocess
+
+    monkeypatch.setattr(subprocess, "run", make_git_subprocess_mock(mapping))
+
+    with pytest.raises(git_module.typer.Exit):
+        git_module.stage_and_commit_file_if_needed(
+            repo_root=tmp_path,
+            relative_path="pipe.yaml",
+            commit_message="test commit",
+            action="Migrate",
+        )

--- a/orchestra_cli/utils/git.py
+++ b/orchestra_cli/utils/git.py
@@ -2,11 +2,18 @@ import random
 import re
 import string
 import subprocess
+from enum import StrEnum
 from pathlib import Path
 
 import typer
 
 from .styling import bold, red, yellow
+
+
+class GitAction(StrEnum):
+    BUILD = "Build"
+    MIGRATE = "Migrate"
+    UPDATE = "Update"
 
 
 def run_git_command(args: list[str], cwd: Path) -> tuple[bool, str]:
@@ -118,7 +125,7 @@ def is_branch_protection_error(message: str) -> bool:
     )
 
 
-def ensure_repo_relative_path(path: Path, repo_root: Path, action: str) -> str:
+def ensure_repo_relative_path(path: Path, repo_root: Path, action: GitAction) -> str:
     try:
         return str(path.resolve().relative_to(repo_root.resolve()))
     except Exception:
@@ -126,7 +133,7 @@ def ensure_repo_relative_path(path: Path, repo_root: Path, action: str) -> str:
         raise typer.Exit(code=1)
 
 
-def require_repo_root(path: Path, action: str) -> Path:
+def require_repo_root(path: Path, action: GitAction) -> Path:
     repo_root = detect_repo_root(path.parent)
     if repo_root is not None:
         return repo_root
@@ -190,7 +197,7 @@ def suggest_migration_branch_name() -> str:
     return f"orchestra-migrate-pipeline-{suffix}"
 
 
-def _require_current_branch(repo_root: Path, action: str) -> str:
+def _require_current_branch(repo_root: Path, action: GitAction) -> str:
     ok, branch = run_git_command(["rev-parse", "--abbrev-ref", "HEAD"], repo_root)
     if ok and branch:
         return branch
@@ -201,7 +208,7 @@ def _require_current_branch(repo_root: Path, action: str) -> str:
     raise typer.Exit(code=1)
 
 
-def _require_head_commit(repo_root: Path, action: str) -> str:
+def _require_head_commit(repo_root: Path, action: GitAction) -> str:
     ok, head_commit = run_git_command(["rev-parse", "HEAD"], repo_root)
     if ok and head_commit:
         return head_commit
@@ -268,7 +275,7 @@ def _pipeline_name_for_commit_message(existing_pipeline: dict[str, object], path
     return path.stem
 
 
-def _stage_selected_file(repo_root: Path, relative_path: str, action: str) -> None:
+def _stage_selected_file(repo_root: Path, relative_path: str, action: GitAction) -> None:
     ok, output = run_git_command(["add", "--", relative_path], repo_root)
     if ok:
         return
@@ -287,7 +294,7 @@ def stage_and_commit_file_if_needed(
     repo_root: Path,
     relative_path: str,
     commit_message: str,
-    action: str,
+    action: GitAction,
 ) -> None:
     ok, status_output = run_git_command(["status", "--porcelain", "--", relative_path], repo_root)
     if not ok:
@@ -310,7 +317,7 @@ def stage_and_commit_file_if_needed(
     raise typer.Exit(code=1)
 
 
-def _push_current_branch(repo_root: Path, action: str) -> tuple[bool, str]:
+def _push_current_branch(repo_root: Path, action: GitAction) -> tuple[bool, str]:
     branch = _require_current_branch(repo_root, action)
     return push_branch(repo_root, branch)
 
@@ -338,7 +345,7 @@ def _recover_on_new_branch(
     commit_was_created: bool,
     failure_output: str,
     force: bool,
-    action: str,
+    action: GitAction,
 ) -> tuple[str, str]:
     typer.echo(red(f"❌ {action} failed while committing/pushing on the current branch."))
     if failure_output:
@@ -410,7 +417,7 @@ def prepare_git_backed_run_target(
     path: Path,
     existing_pipeline: dict[str, object],
     force: bool,
-    action: str = "Build",
+    action: GitAction = GitAction.BUILD,
 ) -> tuple[str, str]:
     repo_root = require_repo_root(path, action)
     relative_path = ensure_repo_relative_path(path, repo_root, action)

--- a/orchestra_cli/utils/git.py
+++ b/orchestra_cli/utils/git.py
@@ -190,23 +190,6 @@ def suggest_migration_branch_name() -> str:
     return f"orchestra-migrate-pipeline-{suffix}"
 
 
-def _require_repo_root(path: Path, action: str) -> Path:
-    repo_root = detect_repo_root(path.parent)
-    if repo_root is not None:
-        return repo_root
-
-    typer.echo(red(f"❌ {action} failed: YAML file must be inside a git repository"))
-    raise typer.Exit(code=1)
-
-
-def _require_repo_relative_path(path: Path, repo_root: Path, action: str) -> str:
-    try:
-        return str(path.resolve().relative_to(repo_root.resolve()))
-    except Exception:
-        typer.echo(red(f"❌ {action} failed: YAML file must be inside the git repository"))
-        raise typer.Exit(code=1)
-
-
 def _require_current_branch(repo_root: Path, action: str) -> str:
     ok, branch = run_git_command(["rev-parse", "--abbrev-ref", "HEAD"], repo_root)
     if ok and branch:
@@ -329,16 +312,21 @@ def stage_and_commit_file_if_needed(
 
 def _push_current_branch(repo_root: Path, action: str) -> tuple[bool, str]:
     branch = _require_current_branch(repo_root, action)
+    return push_branch(repo_root, branch)
+
+
+def push_branch(repo_root: Path, branch_name: str) -> tuple[bool, str]:
     has_upstream, _ = run_git_command(
         ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
         repo_root,
     )
     if has_upstream:
-        return run_git_command(["push"], repo_root)
-    return run_git_command(["push", "-u", "origin", branch], repo_root)
-
-
-def _push_branch(repo_root: Path, branch_name: str) -> tuple[bool, str]:
+        ok_current, current_branch = run_git_command(
+            ["rev-parse", "--abbrev-ref", "HEAD"],
+            repo_root,
+        )
+        if ok_current and current_branch == branch_name:
+            return run_git_command(["push"], repo_root)
     return run_git_command(["push", "-u", "origin", branch_name], repo_root)
 
 
@@ -408,7 +396,7 @@ def _recover_on_new_branch(
                 typer.echo(yellow(commit_output))
             raise typer.Exit(code=1)
 
-    ok, push_output = _push_branch(repo_root, target_branch)
+    ok, push_output = push_branch(repo_root, target_branch)
     if not ok:
         typer.echo(red(f"❌ {action} failed: couldn't push generated branch '{target_branch}'"))
         if push_output:
@@ -424,8 +412,8 @@ def prepare_git_backed_run_target(
     force: bool,
     action: str = "Build",
 ) -> tuple[str, str]:
-    repo_root = _require_repo_root(path, action)
-    relative_path = _require_repo_relative_path(path, repo_root, action)
+    repo_root = require_repo_root(path, action)
+    relative_path = ensure_repo_relative_path(path, repo_root, action)
     include_file_changes = _file_has_uncommitted_changes(repo_root, relative_path)
     has_unpushed_head = _head_is_unpushed(repo_root)
 

--- a/orchestra_cli/utils/git.py
+++ b/orchestra_cli/utils/git.py
@@ -133,8 +133,15 @@ def ensure_repo_relative_path(path: Path, repo_root: Path, action: GitAction) ->
         raise typer.Exit(code=1)
 
 
+def _existing_git_search_path(path: Path) -> Path:
+    candidate = path if path.exists() and path.is_dir() else path.parent
+    while not candidate.exists() and candidate != candidate.parent:
+        candidate = candidate.parent
+    return candidate
+
+
 def require_repo_root(path: Path, action: GitAction) -> Path:
-    repo_root = detect_repo_root(path.parent)
+    repo_root = detect_repo_root(_existing_git_search_path(path))
     if repo_root is not None:
         return repo_root
 
@@ -295,7 +302,7 @@ def stage_and_commit_file_if_needed(
     relative_path: str,
     commit_message: str,
     action: GitAction,
-) -> None:
+) -> bool:
     ok, status_output = run_git_command(["status", "--porcelain", "--", relative_path], repo_root)
     if not ok:
         typer.echo(red(f"❌ {action} failed: could not inspect git status"))
@@ -304,12 +311,12 @@ def stage_and_commit_file_if_needed(
         raise typer.Exit(code=1)
 
     if not status_output:
-        return
+        return False
 
     _stage_selected_file(repo_root, relative_path, action)
     ok, commit_output = _commit_selected_file(repo_root, commit_message)
     if ok or "nothing to commit" in commit_output.lower():
-        return
+        return ok
 
     typer.echo(red(f"❌ {action} failed: could not commit YAML file"))
     if commit_output:

--- a/orchestra_cli/utils/git.py
+++ b/orchestra_cli/utils/git.py
@@ -300,6 +300,33 @@ def _commit_selected_file(repo_root: Path, commit_message: str) -> tuple[bool, s
     return run_git_command(["commit", "-m", commit_message], repo_root)
 
 
+def stage_and_commit_file_if_needed(
+    repo_root: Path,
+    relative_path: str,
+    commit_message: str,
+    action: str,
+) -> None:
+    ok, status_output = run_git_command(["status", "--porcelain", "--", relative_path], repo_root)
+    if not ok:
+        typer.echo(red(f"❌ {action} failed: could not inspect git status"))
+        if status_output:
+            typer.echo(yellow(status_output))
+        raise typer.Exit(code=1)
+
+    if not status_output:
+        return
+
+    _stage_selected_file(repo_root, relative_path, action)
+    ok, commit_output = _commit_selected_file(repo_root, commit_message)
+    if ok or "nothing to commit" in commit_output.lower():
+        return
+
+    typer.echo(red(f"❌ {action} failed: could not commit YAML file"))
+    if commit_output:
+        typer.echo(yellow(commit_output))
+    raise typer.Exit(code=1)
+
+
 def _push_current_branch(repo_root: Path, action: str) -> tuple[bool, str]:
     branch = _require_current_branch(repo_root, action)
     has_upstream, _ = run_git_command(

--- a/orchestra_cli/utils/git.py
+++ b/orchestra_cli/utils/git.py
@@ -33,8 +33,8 @@ def detect_repo_root(start_path: Path) -> Path | None:
 
 
 def detect_repository_slug(repo_root: Path) -> str | None:
-    ok, remote = run_git_command(["remote", "get-url", "origin"], repo_root)
-    if not ok or not remote:
+    remote = get_remote_url(repo_root)
+    if not remote:
         return None
 
     cleaned_remote = re.sub(r"/(?:_git|scm|v3)(?=/)", "", remote.strip())
@@ -44,6 +44,95 @@ def detect_repository_slug(repo_root: Path) -> str | None:
         return f"{match.group(1)}/{match.group(2)}"
 
     return None
+
+
+def get_remote_url(repo_root: Path) -> str | None:
+    ok, remote = run_git_command(["remote", "get-url", "origin"], repo_root)
+    if not ok or not remote:
+        return None
+    return remote.strip()
+
+
+def detect_default_branch(repo_root: Path) -> str | None:
+    ok, out = run_git_command(["symbolic-ref", "refs/remotes/origin/HEAD"], repo_root)
+    if ok and out:
+        return out.split("/")[-1]
+
+    ok, out = run_git_command(["remote", "show", "origin"], repo_root)
+    if ok and out:
+        match = re.search(r"HEAD branch:\s*(\S+)", out)
+        if match:
+            return match.group(1)
+
+    return None
+
+
+def detect_current_branch(repo_root: Path, allow_detached: bool = True) -> str | None:
+    ok, out = run_git_command(["rev-parse", "--abbrev-ref", "HEAD"], repo_root)
+    if not ok or not out:
+        return None
+    if out == "HEAD" and not allow_detached:
+        return None
+    return out
+
+
+def detect_storage_provider(repository_url: str | None) -> str | None:
+    if not repository_url:
+        return None
+
+    url = repository_url.lower()
+    if "github.com" in url:
+        return "GITHUB"
+    if "gitlab.com" in url:
+        return "GITLAB"
+    if any(host in url for host in ("dev.azure.com", "azure.com", "visualstudio.com")):
+        return "AZURE_DEVOPS"
+    return None
+
+
+def build_compare_link(
+    storage_provider: str,
+    repository_slug: str,
+    default_branch: str,
+    branch_name: str,
+) -> str | None:
+    provider = storage_provider.upper()
+    if provider == "GITHUB":
+        return f"https://github.com/{repository_slug}/compare/{default_branch}...{branch_name}?expand=1"
+    if provider == "GITLAB":
+        return f"https://gitlab.com/{repository_slug}/-/compare/{default_branch}...{branch_name}"
+    return None
+
+
+def is_branch_protection_error(message: str) -> bool:
+    lowered = message.lower()
+    return any(
+        token in lowered
+        for token in (
+            "branch protection",
+            "protected branch",
+            "hook declined",
+            "cannot force-push",
+            "pre-receive hook declined",
+        )
+    )
+
+
+def ensure_repo_relative_path(path: Path, repo_root: Path, action: str) -> str:
+    try:
+        return str(path.resolve().relative_to(repo_root.resolve()))
+    except Exception:
+        typer.echo(red(f"❌ {action} failed: YAML file must be inside the git repository"))
+        raise typer.Exit(code=1)
+
+
+def require_repo_root(path: Path, action: str) -> Path:
+    repo_root = detect_repo_root(path.parent)
+    if repo_root is not None:
+        return repo_root
+
+    typer.echo(red(f"❌ {action} failed: YAML file must be inside a git repository"))
+    raise typer.Exit(code=1)
 
 
 def git_warnings(repo_root: Path) -> list[str]:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Objective
Add support for migrating Orchestra-backed pipelines to git-backed storage from the CLI.

## Changes
- Added a new `pipeline migrate` command that handles selector resolution, YAML source selection, git commit/push flow, and storage settings migration.
- Added shared git helper utilities and reused them in import/migrate flows, including shared stage/commit and branch push behavior.
- Added `--force/--no-force` support to `pipeline migrate` so all interactive flows have a non-interactive bypass.
- Removed redundant git helper duplication and aligned migrate/build/update retry logic with shared utility behavior.
- Added command coverage and migration workflow tests.
- Updated CLI documentation to include the migrate command.

## Testing
Unit tested and lint/type checked.

## Checklist
- [x] Verified these changes are backwards compatible (db migrations, model updates)

## Additional Notes

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-9793](https://linear.app/getorchestra/issue/ENG-9793/add-pipeline-migrate-command)

<div><a href="https://cursor.com/agents/bc-8cd44e91-56ff-497a-8739-44c17cce5804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8cd44e91-56ff-497a-8739-44c17cce5804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

