### PR TITLE
[ENG-10177] Fix duplicate key YAML validation

### DIFF
--- a/orchestra_cli/tests/test_validate_pipeline.py
+++ b/orchestra_cli/tests/test_validate_pipeline.py
@@ -1,3 +1,6 @@
+import json
+
+from pytest_httpx import HTTPXMock
 from typer.testing import CliRunner
 
 from orchestra_cli.src.cli import app
@@ -9,3 +12,79 @@ def test_validate_missing_file():
     result = runner.invoke(app, ["pipeline", "validate", "not_a_file.yaml"])
     assert result.exit_code == 1
     assert "File not found" in result.output
+
+
+def test_validate_success_posts_expected_json(tmp_path, httpx_mock: HTTPXMock):
+    pipeline_file = tmp_path / "pipeline.yaml"
+    pipeline_file.write_text(
+        "\n".join(
+            [
+                "pipeline:",
+                "  pre-daily:",
+                "    TaskGroupModel:",
+                "      tasks:",
+                "        dbt-run-pre-daily:",
+                "          task_type: dbt",
+                "          connection: GCP_CLOUD_RUN",
+            ],
+        ),
+    )
+    expected_payload = {
+        "pipeline": {
+            "pre-daily": {
+                "TaskGroupModel": {
+                    "tasks": {
+                        "dbt-run-pre-daily": {
+                            "task_type": "dbt",
+                            "connection": "GCP_CLOUD_RUN",
+                        },
+                    },
+                },
+            },
+        },
+    }
+
+    httpx_mock.add_response(
+        method="POST",
+        url="https://app.getorchestra.io/api/engine/public/pipelines/schema",
+        json={"ok": True},
+        status_code=200,
+    )
+
+    result = runner.invoke(app, ["pipeline", "validate", str(pipeline_file)])
+
+    assert result.exit_code == 0
+    assert "Validation passed" in result.output
+
+    requests = httpx_mock.get_requests()
+    assert len(requests) == 1
+    assert requests[0].url == "https://app.getorchestra.io/api/engine/public/pipelines/schema"
+    assert json.loads(requests[0].content) == expected_payload
+
+
+def test_validate_fails_on_duplicate_yaml_keys(tmp_path):
+    bad = tmp_path / "bad.yaml"
+    bad.write_text(
+        "\n".join(
+            [
+                "pipeline:",
+                "  pre-daily:",
+                "    connection: first",
+                "    connection: second",
+                "  pre-daily:",
+                "    connection: first",
+                "    connection: second",
+            ],
+        ),
+    )
+
+    result = runner.invoke(app, ["pipeline", "validate", str(bad)])
+
+    assert result.exit_code == 1
+    assert "Invalid YAML:" in result.output
+    assert '"detail"' in result.output
+    assert '"loc"' in result.output
+    assert '"pipeline"' in result.output
+    assert '"pre-daily"' in result.output
+    assert '"connection"' in result.output
+    assert "Duplicate key found in YAML: 'connection'" in result.output

--- a/orchestra_cli/tests/test_validate_pipeline.py
+++ b/orchestra_cli/tests/test_validate_pipeline.py
@@ -71,9 +71,9 @@ def test_validate_fails_on_duplicate_yaml_keys(tmp_path):
                 "  pre-daily:",
                 "    connection: first",
                 "    connection: second",
-                "  pre-daily:",
-                "    connection: first",
-                "    connection: second",
+                "metadata:",
+                "  team: data",
+                "  team: analytics",
             ],
         ),
     )
@@ -87,4 +87,7 @@ def test_validate_fails_on_duplicate_yaml_keys(tmp_path):
     assert '"pipeline"' in result.output
     assert '"pre-daily"' in result.output
     assert '"connection"' in result.output
+    assert '"metadata"' in result.output
+    assert '"team"' in result.output
     assert "Duplicate key found in YAML: 'connection'" in result.output
+    assert "Duplicate key found in YAML: 'team'" in result.output

--- a/orchestra_cli/utils/yaml_loader.py
+++ b/orchestra_cli/utils/yaml_loader.py
@@ -7,6 +7,7 @@ command having to import private functions from another.
 
 import json
 from pathlib import Path
+from typing import Any
 
 import httpx
 import typer
@@ -16,12 +17,60 @@ from .constants import get_api_url
 from .styling import indent_message, red, yellow
 
 
+class DuplicateKeyYAMLError(Exception):
+    def __init__(self, loc: list[str], key: Any):
+        self.loc = loc
+        self.key = key
+        super().__init__(f"Duplicate key found: {key!r}")
+
+
+class DuplicateKeySafeLoader(yaml.SafeLoader):
+    def __init__(self, stream):
+        super().__init__(stream)
+        self.path_stack: list[str] = []
+
+    def construct_mapping(self, node, deep=False):  # type: ignore[override]
+        self.flatten_mapping(node)
+        mapping: dict[Any, Any] = {}
+
+        for key_node, value_node in node.value:
+            key = self.construct_object(key_node, deep=True)
+            key_str = str(key)
+
+            if key in mapping:
+                raise DuplicateKeyYAMLError(loc=[*self.path_stack, key_str], key=key)
+
+            self.path_stack.append(key_str)
+            try:
+                mapping[key] = self.construct_object(value_node, deep=True)
+            finally:
+                self.path_stack.pop()
+
+        return mapping
+
+
 def load_yaml(file: Path) -> tuple[dict | None, str | None]:
     """Read a YAML file and return ``(data, None)`` or ``(None, error_message)``."""
     try:
         with file.open("r") as f:
-            data = yaml.safe_load(f)
+            data = yaml.load(f, Loader=DuplicateKeySafeLoader)
         return data, None
+    except DuplicateKeyYAMLError as e:
+        return (
+            None,
+            json.dumps(
+                {
+                    "detail": [
+                        {
+                            "loc": e.loc,
+                            "msg": f"Duplicate key found in YAML: {e.key!r}",
+                            "type": "value_error",
+                        },
+                    ],
+                },
+                indent=2,
+            ),
+        )
     except Exception as e:
         return None, str(e)
 

--- a/orchestra_cli/utils/yaml_loader.py
+++ b/orchestra_cli/utils/yaml_loader.py
@@ -18,16 +18,22 @@ from .styling import indent_message, red, yellow
 
 
 class DuplicateKeyYAMLError(Exception):
-    def __init__(self, loc: list[str], key: Any):
-        self.loc = loc
-        self.key = key
-        super().__init__(f"Duplicate key found: {key!r}")
+    def __init__(self, details: list[dict[str, Any]]):
+        self.details = details
+        super().__init__("Duplicate keys found in YAML")
 
 
 class DuplicateKeySafeLoader(yaml.SafeLoader):
     def __init__(self, stream):
         super().__init__(stream)
         self.path_stack: list[str] = []
+        self.duplicate_key_details: list[dict[str, Any]] = []
+
+    def get_single_data(self):  # type: ignore[override]
+        data = super().get_single_data()
+        if self.duplicate_key_details:
+            raise DuplicateKeyYAMLError(details=self.duplicate_key_details)
+        return data
 
     def construct_mapping(self, node, deep=False):  # type: ignore[override]
         # PyYAML passes this argument for recursive construction; this loader
@@ -41,11 +47,19 @@ class DuplicateKeySafeLoader(yaml.SafeLoader):
             key_str = str(key)
 
             if key in mapping:
-                raise DuplicateKeyYAMLError(loc=[*self.path_stack, key_str], key=key)
+                self.duplicate_key_details.append(
+                    {
+                        "loc": [*self.path_stack, key_str],
+                        "msg": f"Duplicate key found in YAML: {key!r}",
+                        "type": "value_error",
+                    },
+                )
 
             self.path_stack.append(key_str)
             try:
-                mapping[key] = self.construct_object(value_node, deep=True)
+                value = self.construct_object(value_node, deep=True)
+                if key not in mapping:
+                    mapping[key] = value
             finally:
                 self.path_stack.pop()
 
@@ -63,13 +77,7 @@ def load_yaml(file: Path) -> tuple[dict | None, str | None]:
             None,
             json.dumps(
                 {
-                    "detail": [
-                        {
-                            "loc": e.loc,
-                            "msg": f"Duplicate key found in YAML: {e.key!r}",
-                            "type": "value_error",
-                        },
-                    ],
+                    "detail": e.details,
                 },
                 indent=2,
             ),

--- a/orchestra_cli/utils/yaml_loader.py
+++ b/orchestra_cli/utils/yaml_loader.py
@@ -30,6 +30,9 @@ class DuplicateKeySafeLoader(yaml.SafeLoader):
         self.path_stack: list[str] = []
 
     def construct_mapping(self, node, deep=False):  # type: ignore[override]
+        # PyYAML passes this argument for recursive construction; this loader
+        # always constructs keys/values deeply to track duplicate paths reliably.
+        _ = deep
         self.flatten_mapping(node)
         mapping: dict[Any, Any] = {}
 


### PR DESCRIPTION
<!-- Please ensure that the JIRA ticket ID is included in either the PR title, description, or branch. -->

# Objective
Fail fast on duplicate YAML keys with API-style validation output.

## Changes
- Detect duplicate keys during YAML parsing instead of allowing silent overwrites
- Return duplicate-key failures in the same `detail` structure used by schema validation responses
- Add validation tests for duplicate-key failures and happy-path schema payload submission

## Testing
Unit tested

## Checklist
- [x] Verified these changes are backwards compatible (db migrations, model updates)

## Additional Notes
Linked Linear issue: https://linear.app/getorchestra/issue/ENG-10177/fix-pipeline-yaml-validation-with-duplicate-keys

Made with [Cursor](https://cursor.com)