### PR TITLE
ENG-11472 - Publish orchestra-cli to the Homebrew tap on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,13 +77,15 @@ jobs:
           exit 1
 
       # Mints an installation token scoped to the tap for the length of this
-      # job, and revokes it on the way out. Nothing long-lived to rotate.
+      # job, and revokes it on the way out. Nothing long-lived to rotate. Uses
+      # the same release App as orchestra-hq/atlas, which already publishes to
+      # this tap — see that repo's release.yml.
       - name: Mint a token for the tap
         id: tap-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ secrets.HOMEBREW_TAP_APP_CLIENT_ID }}
-          private-key: ${{ secrets.HOMEBREW_TAP_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           owner: orchestra-hq
           repositories: homebrew-tap
           permission-contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,11 +76,23 @@ jobs:
           echo "orchestra-cli ${VERSION} did not appear on PyPI within 5 minutes" >&2
           exit 1
 
+      # Mints an installation token scoped to the tap for the length of this
+      # job, and revokes it on the way out. Nothing long-lived to rotate.
+      - name: Mint a token for the tap
+        id: tap-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.HOMEBREW_TAP_APP_CLIENT_ID }}
+          private-key: ${{ secrets.HOMEBREW_TAP_APP_PRIVATE_KEY }}
+          owner: orchestra-hq
+          repositories: homebrew-tap
+          permission-contents: write
+
       - name: Checkout the tap
         uses: actions/checkout@v4
         with:
           repository: orchestra-hq/homebrew-tap
-          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          token: ${{ steps.tap-token.outputs.token }}
           path: homebrew-tap
 
       - name: Generate the formula
@@ -88,10 +100,23 @@ jobs:
           python scripts/generate_brew_formula.py \
             --output homebrew-tap/Formula/orchestra-cli.rb
 
+      # The numeric user ID is what links the commit to the app's bot account
+      # rather than leaving it as an unattributed author.
+      - name: Look up the app's bot user ID
+        id: bot
+        env:
+          GH_TOKEN: ${{ steps.tap-token.outputs.token }}
+          APP_SLUG: ${{ steps.tap-token.outputs.app-slug }}
+        run: |
+          user_id=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)
+          echo "user-id=${user_id}" >> "$GITHUB_OUTPUT"
+
       - name: Commit and push to the tap
         working-directory: homebrew-tap
         env:
           VERSION: ${{ steps.release.outputs.version }}
+          APP_SLUG: ${{ steps.tap-token.outputs.app-slug }}
+          BOT_USER_ID: ${{ steps.bot.outputs.user-id }}
         run: |
           # --porcelain rather than `git diff`, so that the very first run sees
           # the formula while it is still untracked.
@@ -99,8 +124,8 @@ jobs:
             echo "Formula is already up to date; nothing to push"
             exit 0
           fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${BOT_USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
           git add Formula/orchestra-cli.rb
           git commit -m "Brew formula update for orchestra-cli version ${VERSION}"
           git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    # Two of our own releases must not race each other onto the tap: they touch
+    # the same formula, so the loser would hit a rebase conflict rather than a
+    # simple retry. Queue them instead of cancelling — every release needs to
+    # land, not just the newest.
+    concurrency:
+      group: homebrew-tap-push
+      cancel-in-progress: false
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -130,4 +137,21 @@ jobs:
           git config user.email "${BOT_USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
           git add Formula/orchestra-cli.rb
           git commit -m "Brew formula update for orchestra-cli version ${VERSION}"
-          git push
+
+          # atlas releases to this same tap, so HEAD can move under us between
+          # checkout and push. Those commits touch Formula/atlas.rb, so a rebase
+          # replays ours cleanly; the concurrency group above keeps our own
+          # releases from colliding on Formula/orchestra-cli.rb.
+          for attempt in $(seq 1 5); do
+            if git push; then
+              exit 0
+            fi
+            echo "Attempt ${attempt}: push rejected, rebasing onto the latest tap"
+            if ! git pull --rebase origin "$(git rev-parse --abbrev-ref HEAD)"; then
+              git rebase --abort || true
+              echo "Could not rebase onto the tap; resolve by hand" >&2
+              exit 1
+            fi
+          done
+          echo "Could not push the formula after 5 attempts" >&2
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,3 +33,74 @@ jobs:
         env:
           UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         run: uv publish --token ${UV_PUBLISH_TOKEN}
+
+  # Only runs when build-and-publish succeeded, which requires the version in
+  # pyproject.toml to be new — PyPI rejects a duplicate upload. Merges that do
+  # not bump the version therefore leave the tap pointing at the last release.
+  update-homebrew-tap:
+    needs: build-and-publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Read released version
+        id: release
+        run: |
+          version=$(python -c 'import pathlib, tomllib; print(tomllib.loads(pathlib.Path("pyproject.toml").read_text())["project"]["version"])')
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for the release to appear on PyPI
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          url="https://pypi.org/pypi/orchestra-cli/${VERSION}/json"
+          for attempt in $(seq 1 30); do
+            if curl -fsS -o /dev/null "$url"; then
+              echo "orchestra-cli ${VERSION} is available on PyPI"
+              exit 0
+            fi
+            echo "Attempt ${attempt}: not indexed yet, retrying in 10s"
+            sleep 10
+          done
+          echo "orchestra-cli ${VERSION} did not appear on PyPI within 5 minutes" >&2
+          exit 1
+
+      - name: Checkout the tap
+        uses: actions/checkout@v4
+        with:
+          repository: orchestra-hq/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-tap
+
+      - name: Generate the formula
+        run: |
+          python scripts/generate_brew_formula.py \
+            --output homebrew-tap/Formula/orchestra-cli.rb
+
+      - name: Commit and push to the tap
+        working-directory: homebrew-tap
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          # --porcelain rather than `git diff`, so that the very first run sees
+          # the formula while it is still untracked.
+          if [ -z "$(git status --porcelain -- Formula/orchestra-cli.rb)" ]; then
+            echo "Formula is already up to date; nothing to push"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Formula/orchestra-cli.rb
+          git commit -m "Brew formula update for orchestra-cli version ${VERSION}"
+          git push

--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,6 @@ build:
 
 publish:
 	uv publish
+
+brew-formula:
+	uv run python scripts/generate_brew_formula.py --output Formula/orchestra-cli.rb

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,11 @@ line-length = 100
 # N = pep8-naming
 select = ["E", "F", "W", "I", "N", "UP", "ARG", "COM"]
 
+[tool.ruff.lint.isort]
+# `requires-python = ">=3.10"` makes ruff classify tomllib as third-party, but
+# the dev scripts that import it run on 3.12.
+extra-standard-library = ["tomllib"]
+
 [tool.black]
 line-length = 100
 exclude = '''

--- a/scripts/generate_brew_formula.py
+++ b/scripts/generate_brew_formula.py
@@ -1,0 +1,329 @@
+"""Generate the Homebrew formula for orchestra-cli.
+
+The formula is pinned to a published PyPI release and vendors every runtime
+dependency as a Homebrew ``resource`` block, because Homebrew builds Python
+formulae in a network-isolated sandbox.
+
+Dependencies listed in :data:`WHEEL_PACKAGES` are pinned to prebuilt wheels
+rather than source distributions. Only ``pydantic-core`` needs this: it is a
+Rust extension module, and building it from source would force every user to
+download a Rust toolchain. Everything else is installed from an sdist, which is
+what Homebrew expects.
+
+Usage:
+    uv run python scripts/generate_brew_formula.py --output Formula/orchestra-cli.rb
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+import tomllib
+import urllib.request
+from dataclasses import dataclass
+from fnmatch import fnmatch
+from pathlib import Path
+
+PYPI_URL = "https://pypi.org/pypi/{name}/{version}/json"
+PROJECT_NAME = "orchestra-cli"
+
+# The Python that the formula builds against. PYTHON_TAG must be the CPython
+# interpreter tag matching PYTHON_FORMULA, since wheels are selected by it.
+PYTHON_FORMULA = "python@3.13"
+PYTHON_TAG = "cp313"
+PYTHON_BINARY = "python3.13"
+
+# Packages installed from prebuilt wheels instead of source. Add a package here
+# when compiling it from source would require a toolchain we do not want to
+# make users install.
+WHEEL_PACKAGES = frozenset({"pydantic-core"})
+
+# Environment markers from `uv export` that never apply to a Homebrew install.
+# Anything not listed here raises, so a new marker fails the build loudly rather
+# than silently dropping or including a dependency.
+IGNORED_MARKERS = frozenset(
+    {
+        "sys_platform == 'win32'",
+        "python_full_version < '3.11'",
+    },
+)
+
+
+@dataclass(frozen=True)
+class WheelTarget:
+    """A platform Homebrew can install on, and the wheel tags that serve it."""
+
+    os_block: str
+    arch_block: str
+    platform_glob: str
+
+
+WHEEL_TARGETS = (
+    WheelTarget("on_macos", "on_arm", "macosx_*_arm64"),
+    WheelTarget("on_macos", "on_intel", "macosx_*_x86_64"),
+    WheelTarget("on_linux", "on_arm", "manylinux*_aarch64*"),
+    WheelTarget("on_linux", "on_intel", "manylinux*_x86_64*"),
+)
+
+
+@dataclass(frozen=True)
+class Download:
+    """A single downloadable artefact on PyPI."""
+
+    url: str
+    sha256: str
+
+
+def read_project_version(project_root: Path) -> str:
+    """Return the version declared in pyproject.toml."""
+    # Read pyproject.toml directly rather than shelling out to `uv version`,
+    # which only reports the project version on uv >= 0.7 and reports uv's own
+    # version before that.
+    data = tomllib.loads((project_root / "pyproject.toml").read_text())
+    return data["project"]["version"]
+
+
+def resolve_runtime_dependencies(project_root: Path) -> dict[str, str]:
+    """Return the locked runtime dependency closure as ``{name: version}``.
+
+    Reads `uv.lock` via `uv export` so the formula always matches the versions
+    the project is actually tested against.
+    """
+    result = subprocess.run(
+        ["uv", "export", "--no-dev", "--no-emit-project", "--no-hashes"],
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    dependencies: dict[str, str] = {}
+    for raw_line in result.stdout.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or line.startswith("-"):
+            continue
+
+        requirement, _, marker = line.partition(";")
+        marker = marker.strip()
+        if marker:
+            if marker not in IGNORED_MARKERS:
+                raise ValueError(
+                    f"Unrecognised environment marker {marker!r} on {requirement.strip()!r}. "
+                    f"Add it to IGNORED_MARKERS if it never applies to a Homebrew install, "
+                    f"otherwise handle it explicitly.",
+                )
+            continue
+
+        name, _, version = requirement.strip().partition("==")
+        if not version:
+            raise ValueError(f"Expected a pinned requirement, got {line!r}")
+        dependencies[name] = version
+
+    return dependencies
+
+
+def fetch_pypi_files(name: str, version: str) -> list[dict]:
+    """Return the PyPI file listing for one release."""
+    with urllib.request.urlopen(PYPI_URL.format(name=name, version=version)) as response:
+        return json.load(response)["urls"]
+
+
+def select_sdist(name: str, version: str, files: list[dict]) -> Download:
+    """Return the source distribution for a release."""
+    for entry in files:
+        if entry["packagetype"] == "sdist":
+            return Download(entry["url"], entry["digests"]["sha256"])
+    raise ValueError(f"No sdist published for {name} {version}")
+
+
+def select_wheels(name: str, version: str, files: list[dict]) -> dict[WheelTarget, Download]:
+    """Return one wheel per supported platform.
+
+    Prefers a wheel built for :data:`PYTHON_TAG` exactly, falling back to a
+    stable-ABI (``abi3``) wheel where a package publishes one.
+    """
+    wheels: dict[WheelTarget, Download] = {}
+    for target in WHEEL_TARGETS:
+        candidates = [
+            entry
+            for entry in files
+            if entry["packagetype"] == "bdist_wheel"
+            and _matches_platform(entry["filename"], target.platform_glob)
+            and _matches_interpreter(entry["filename"])
+        ]
+        if not candidates:
+            raise ValueError(
+                f"No {PYTHON_TAG} wheel for {name} {version} matching "
+                f"{target.platform_glob!r}. Remove it from WHEEL_PACKAGES to build "
+                f"it from source instead.",
+            )
+        # Our targets have exactly one matching wheel each; sort so that a
+        # package publishing several stays deterministic between runs.
+        chosen = sorted(candidates, key=lambda entry: entry["filename"])[0]
+        wheels[target] = Download(chosen["url"], chosen["digests"]["sha256"])
+
+    return wheels
+
+
+def _wheel_tags(filename: str) -> tuple[str, str, str]:
+    """Return the (interpreter, abi, platform) tags of a wheel filename."""
+    parts = filename.removesuffix(".whl").split("-")
+    return parts[-3], parts[-2], parts[-1]
+
+
+def _matches_platform(filename: str, platform_glob: str) -> bool:
+    _, _, platform_tag = _wheel_tags(filename)
+    return fnmatch(platform_tag, platform_glob)
+
+
+def _cpython_version(interpreter_tag: str) -> tuple[int, int] | None:
+    """Return the (major, minor) version of a CPython tag such as ``cp313``.
+
+    The tag concatenates major and minor without a separator, so the first
+    digit is the major version and the remainder is the minor: ``cp39`` is 3.9
+    and ``cp313`` is 3.13. Returns None for non-CPython tags such as ``py3``.
+    """
+    if not interpreter_tag.startswith("cp"):
+        return None
+    digits = interpreter_tag.removeprefix("cp")
+    if not digits.isdigit():
+        return None
+    return int(digits[0]), int(digits[1:])
+
+
+def _matches_interpreter(filename: str) -> bool:
+    interpreter_tag, abi_tag, _ = _wheel_tags(filename)
+    if abi_tag == "abi3":
+        # A stable-ABI wheel works on its own version and every later one.
+        wheel_version = _cpython_version(interpreter_tag)
+        target_version = _cpython_version(PYTHON_TAG)
+        return (
+            wheel_version is not None
+            and target_version is not None
+            and wheel_version <= target_version
+        )
+    return interpreter_tag == PYTHON_TAG and abi_tag == PYTHON_TAG
+
+
+def ruby_class_name(name: str) -> str:
+    """Convert a formula name to its Ruby class name, as Homebrew expects."""
+    return "".join(part.capitalize() for part in name.replace("_", "-").split("-"))
+
+
+def render_simple_resource(name: str, download: Download) -> str:
+    return (
+        f'  resource "{name}" do\n'
+        f'    url "{download.url}"\n'
+        f'    sha256 "{download.sha256}"\n'
+        f"  end\n"
+    )
+
+
+def render_wheel_resource(name: str, wheels: dict[WheelTarget, Download]) -> str:
+    """Render a resource whose URL varies by OS and CPU architecture."""
+    lines = [f'  resource "{name}" do']
+    for os_block in ("on_macos", "on_linux"):
+        lines.append(f"    {os_block} do")
+        for target in WHEEL_TARGETS:
+            if target.os_block != os_block:
+                continue
+            download = wheels[target]
+            lines.append(f"      {target.arch_block} do")
+            lines.append(f'        url "{download.url}", using: :nounzip')
+            lines.append(f'        sha256 "{download.sha256}"')
+            lines.append("      end")
+        lines.append("    end")
+    lines.append("  end\n")
+    return "\n".join(lines)
+
+
+def render_formula(version: str, dependencies: dict[str, str]) -> str:
+    """Render the complete formula source."""
+    project_files = fetch_pypi_files(PROJECT_NAME, version)
+    project_sdist = select_sdist(PROJECT_NAME, version, project_files)
+
+    resources: list[str] = []
+    for name in sorted(dependencies):
+        dependency_version = dependencies[name]
+        files = fetch_pypi_files(name, dependency_version)
+        if name in WHEEL_PACKAGES:
+            wheels = select_wheels(name, dependency_version, files)
+            resources.append(render_wheel_resource(name, wheels))
+        else:
+            sdist = select_sdist(name, dependency_version, files)
+            resources.append(render_simple_resource(name, sdist))
+
+    wheel_names = sorted(WHEEL_PACKAGES & dependencies.keys())
+    wheel_reject = " || ".join(f'r.name == "{name}"' for name in wheel_names)
+    wheel_installs = "\n".join(
+        f'    resource("{name}").stage do\n'
+        f'      venv.pip_install Pathname.pwd/Dir["*.whl"].fetch(0)\n'
+        f"    end"
+        for name in wheel_names
+    )
+
+    return f"""# This file is generated by scripts/generate_brew_formula.py in
+# orchestra-hq/orchestra-cli. Do not edit it by hand.
+class {ruby_class_name(PROJECT_NAME)} < Formula
+  include Language::Python::Virtualenv
+
+  desc "Command-line tool for working with Orchestra pipelines"
+  homepage "https://github.com/orchestra-hq/orchestra-cli"
+  url "{project_sdist.url}"
+  sha256 "{project_sdist.sha256}"
+
+  depends_on "{PYTHON_FORMULA}"
+
+{chr(10).join(resources)}
+  # Homebrew's default pip arguments include --no-binary=:all:, which would
+  # reject the prebuilt wheels above. ":none:" lifts that restriction; every
+  # other resource is still a source distribution.
+  def std_pip_args(prefix: self.prefix, build_isolation: false)
+    super.map {{ |arg| (arg == "--no-binary=:all:") ? "--no-binary=:none:" : arg }}
+  end
+
+  def install
+    venv = virtualenv_create(libexec, "{PYTHON_BINARY}")
+
+    # Homebrew only resolves the filename of pure-Python wheel resources, so
+    # platform-specific wheels have to be staged and installed by path.
+{wheel_installs}
+
+    venv.pip_install resources.reject {{ |r| {wheel_reject} }}
+    venv.pip_install_and_link buildpath
+  end
+
+  test do
+    assert_match "pipeline", shell_output("#{{bin}}/orchestra --help")
+    assert_match "pipeline", shell_output("#{{bin}}/orchestra-cli --help")
+  end
+end
+"""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        required=True,
+        help="Path to write the formula to.",
+    )
+    parser.add_argument(
+        "--version",
+        help="Release to pin. Defaults to the version in pyproject.toml.",
+    )
+    args = parser.parse_args()
+
+    project_root = Path(__file__).resolve().parent.parent
+    version = args.version or read_project_version(project_root)
+    dependencies = resolve_runtime_dependencies(project_root)
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(render_formula(version, dependencies))
+    print(f"Wrote {args.output} for {PROJECT_NAME} {version}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate_brew_formula.py
+++ b/scripts/generate_brew_formula.py
@@ -16,6 +16,7 @@ Usage:
 
 import argparse
 import json
+import re
 import subprocess
 import sys
 import tomllib
@@ -26,6 +27,10 @@ from pathlib import Path
 
 PYPI_URL = "https://pypi.org/pypi/{name}/{version}/json"
 PROJECT_NAME = "orchestra-cli"
+
+# Bounded so that a PyPI connection which opens but never responds fails the
+# release job instead of hanging it.
+PYPI_TIMEOUT_SECONDS = 30
 
 # The Python that the formula builds against. PYTHON_TAG must be the CPython
 # interpreter tag matching PYTHON_FORMULA, since wheels are selected by it.
@@ -124,7 +129,8 @@ def resolve_runtime_dependencies(project_root: Path) -> dict[str, str]:
 
 def fetch_pypi_files(name: str, version: str) -> list[dict]:
     """Return the PyPI file listing for one release."""
-    with urllib.request.urlopen(PYPI_URL.format(name=name, version=version)) as response:
+    url = PYPI_URL.format(name=name, version=version)
+    with urllib.request.urlopen(url, timeout=PYPI_TIMEOUT_SECONDS) as response:
         return json.load(response)["urls"]
 
 
@@ -157,9 +163,7 @@ def select_wheels(name: str, version: str, files: list[dict]) -> dict[WheelTarge
                 f"{target.platform_glob!r}. Remove it from WHEEL_PACKAGES to build "
                 f"it from source instead.",
             )
-        # Our targets have exactly one matching wheel each; sort so that a
-        # package publishing several stays deterministic between runs.
-        chosen = sorted(candidates, key=lambda entry: entry["filename"])[0]
+        chosen = sorted(candidates, key=lambda entry: _wheel_preference(entry["filename"]))[0]
         wheels[target] = Download(chosen["url"], chosen["digests"]["sha256"])
 
     return wheels
@@ -169,6 +173,30 @@ def _wheel_tags(filename: str) -> tuple[str, str, str]:
     """Return the (interpreter, abi, platform) tags of a wheel filename."""
     parts = filename.removesuffix(".whl").split("-")
     return parts[-3], parts[-2], parts[-1]
+
+
+def _platform_baseline(platform_tag: str) -> tuple[int, int]:
+    """Return the minimum OS version a platform tag requires.
+
+    ``macosx_10_12_x86_64`` is (10, 12) and ``manylinux_2_17_aarch64`` is
+    (2, 17). Legacy tags without an embedded version (``manylinux1_x86_64``)
+    return (0, 0), which correctly ranks them as the most compatible.
+    """
+    match = re.search(r"(?:macosx|manylinux)_(\d+)_(\d+)", platform_tag)
+    if match is None:
+        return 0, 0
+    return int(match.group(1)), int(match.group(2))
+
+
+def _wheel_preference(filename: str) -> tuple[int, tuple[int, int], str]:
+    """Return a sort key ranking wheels best-first.
+
+    An exact-interpreter wheel beats a stable-ABI one, and among equals the
+    lowest OS baseline wins because it runs on the widest range of machines.
+    The filename breaks any remaining tie so runs stay deterministic.
+    """
+    _, abi_tag, platform_tag = _wheel_tags(filename)
+    return (1 if abi_tag == "abi3" else 0), _platform_baseline(platform_tag), filename
 
 
 def _matches_platform(filename: str, platform_glob: str) -> bool:


### PR DESCRIPTION
# Objective
Let users install orchestra-cli with Homebrew.

## Changes
- Generate the Homebrew formula from the locked runtime dependency closure
- Push the regenerated formula to `orchestra-hq/homebrew-tap` after each PyPI publish
- Install `pydantic-core` from prebuilt wheels so the formula needs no Rust toolchain
- Add a `make brew-formula` target for regenerating the formula by hand

## Testing
Installed from the tap with `brew install --build-from-source` on macOS arm64: the formula builds, both entrypoints run, and `pydantic_core` lands in the venv from the prebuilt wheel with no Rust in the dependency tree. Generator output is deterministic and passes a Ruby syntax check; each release step was rehearsed locally against the real PyPI index.

The release job itself stays unverified until the next version bump — its cross-repo push and token minting cannot be exercised locally.

## Checklist
- [ ] Verified these changes are backwards compatible (db migrations, model updates)

## Additional Notes
**Needs two repo secrets on `orchestra-cli` before merge**, or the next release goes red: `RELEASE_APP_ID` (`4153821`, the public App ID) and `RELEASE_APP_PRIVATE_KEY`. PyPI publishing is unaffected either way — only the new tap job fails.

No new GitHub App is required. `orchestra-hq/atlas` already publishes to this tap via the `tap-releaser` App (renamed from `atlas-releaser`), installed on `homebrew-tap` with `contents: write`. This job reuses it, matching atlas's secret names and SHA-pinned action. Since the App's private key cannot be read back out of atlas's secrets, generate an additional key rather than replacing the existing one — that also lets orchestra-cli's access be revoked independently.

Secrets are at repo level rather than in the `deploy` environment on purpose: `deploy` has required reviewers, so an environment secret would force a second approval per release for a formula update already downstream of the approved publish.

The formula leans on two Homebrew internals, both commented at the call site: `std_pip_args` is overridden because its default `--no-binary=:all:` would reject the wheels, and the wheel resource is staged and installed by path because Homebrew only resolves filenames for pure-Python wheels.